### PR TITLE
docs: anchor-has-content.md

### DIFF
--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -71,8 +71,8 @@ showHero: false
 | Rule | Description |
 | ------------- | ------------- |
 | alt-text |  |
-| anchor-has-content |  |
-| anchor-is-valid |  |
+| [anchor-has-content](/docs/lint/rules/jsx-a11y/anchor-has-content) |  Anchor elements should have contents |
+| [anchor-is-valid](/docs/lint/rules/jsx-a11y/anchor-is-valid) |  Validate the correctness of the `href` attribute |
 | aria-props |  |
 | aria-proptypes |  |
 | aria-unsupported-elements |  |

--- a/website/src/docs/lint/rules/jsx-a11y/anchor-has-content.md
+++ b/website/src/docs/lint/rules/jsx-a11y/anchor-has-content.md
@@ -1,0 +1,39 @@
+---
+title: Rome
+layout: layouts/base.njk
+showHero: false
+description: Anchor elements should have contents
+---
+
+# anchor-has-content
+
+Anchor elements should contain content that can be consumed by screen readers.
+Empty anchor elements are not allowed.
+
+## Invalid
+
+```jsx
+function Component() {
+    return <a />;
+}
+
+function Component() {
+    return <a></a>;
+}
+```
+
+## Valid
+
+```jsx
+function Component() {
+    return <a ><WrapperComponent /></a>;
+}
+
+function Component() {
+    return <a dangerouslySetInnerHTML={{__html: "foo"}}></a>;
+}
+```
+
+## Accessibility guidelines
+- [WCAG 2.4.4](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context)
+- [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)

--- a/website/src/docs/lint/rules/jsx-a11y/anchor-is-valid.md
+++ b/website/src/docs/lint/rules/jsx-a11y/anchor-is-valid.md
@@ -1,0 +1,8 @@
+---
+title: Rome
+layout: layouts/base.njk
+showHero: false
+description: Validate the correctness of the `href` attribute
+---
+
+# anchor-is-valid


### PR DESCRIPTION
I guess we should start writing some documentation. Here's a first a PR. Maybe we should come up with a structure of the page:


```
# <rule name>

Description

## Invalid

## Valid

## Accessibility resources (if applicable)

## Resource (if applicable)

```

I followed more or less the upstream plugin