### PR TITLE
Rename partialServerQueryResponseToFull function

### DIFF
--- a/packages/@romefrontend/core/integrationTestHelpers.ts
+++ b/packages/@romefrontend/core/integrationTestHelpers.ts
@@ -23,7 +23,7 @@ import {UserConfig} from "./common/userConfig";
 import crypto = require("crypto");
 import stream = require("stream");
 import ServerRequest from "./server/ServerRequest";
-import {partialServerQueryResponseToFull} from "./server/Server";
+import {partialServerQueryRequestToFull} from "./server/Server";
 import {PartialServerQueryRequest} from "./common/bridges/ServerBridge";
 
 type IntegrationTestHelper = {
@@ -191,7 +191,7 @@ export function createIntegrationTest(
 						) {
 							return new ServerRequest({
 								client: serverClient,
-								query: partialServerQueryResponseToFull(query),
+								query: partialServerQueryRequestToFull(query),
 								server,
 							});
 						},

--- a/packages/@romefrontend/core/server/Server.ts
+++ b/packages/@romefrontend/core/server/Server.ts
@@ -112,7 +112,7 @@ export type ServerMarker = ServerUnfinishedMarker & {
 
 const disallowedFlagsWhenReviewing: Array<keyof ClientRequestFlags> = ["watch"];
 
-export function partialServerQueryResponseToFull(
+export function partialServerQueryRequestToFull(
 	partialQuery: PartialServerQueryRequest,
 ): ServerQueryRequest {
 	const requestFlags: ClientRequestFlags = {
@@ -758,7 +758,7 @@ export default class Server {
 		client: ServerClient,
 		partialQuery: PartialServerQueryRequest,
 	): Promise<ServerQueryResponse> {
-		const query: ServerQueryRequest = partialServerQueryResponseToFull(
+		const query: ServerQueryRequest = partialServerQueryRequestToFull(
 			partialQuery,
 		);
 


### PR DESCRIPTION
This function is incorrectly named. It turns a `PartialServerQueryRequest` into a full `ServerQueryRequest`.