### PR TITLE
Add incremental sync to LSPServer with buffer patching

### DIFF
--- a/packages/@romefrontend/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romefrontend/core/common/bridges/WorkerBridge.ts
@@ -32,6 +32,7 @@ import {AnalyzeDependencyResult} from "../types/analyzeDependencies";
 import {InlineSnapshotUpdates} from "@romefrontend/core/test-worker/SnapshotManager";
 import {FileNotFound} from "@romefrontend/core/common/FileNotFound";
 import {createAbsoluteFilePath} from "@romefrontend/path";
+import {Number0} from "@romefrontend/ob1";
 
 export type WorkerProjects = Array<{
 	id: number;
@@ -121,6 +122,19 @@ export type WorkerLintResult = {
 	save: undefined | string;
 	diagnostics: Diagnostics;
 	suppressions: DiagnosticSuppressions;
+};
+
+export type WorkerBufferPosition = {
+	line: Number0;
+	character: Number0;
+};
+
+export type WorkerBufferPatch = {
+	range: {
+		start: WorkerBufferPosition;
+		end: WorkerBufferPosition;
+	};
+	text: string;
 };
 
 export default class WorkerBridge extends Bridge {
@@ -262,6 +276,17 @@ export default class WorkerBridge extends Bridge {
 		void
 	>({
 		name: "updateBuffer",
+		direction: "server->client",
+	});
+
+	patchBuffer = this.createEvent<
+		{
+			file: JSONFileReference;
+			patches: Array<WorkerBufferPatch>;
+		},
+		string
+	>({
+		name: "patchBuffer",
 		direction: "server->client",
 	});
 

--- a/packages/@romefrontend/core/server/ServerRequest.ts
+++ b/packages/@romefrontend/core/server/ServerRequest.ts
@@ -58,6 +58,7 @@ import {TransformStageName} from "@romefrontend/compiler";
 import WorkerBridge, {
 	PrefetchedModuleSignatures,
 	WorkerAnalyzeDependencyResult,
+	WorkerBufferPatch,
 	WorkerCompileResult,
 	WorkerCompilerOptions,
 	WorkerFormatResult,
@@ -914,6 +915,25 @@ export default class ServerRequest {
 				await bridge.updateBuffer.call({file, content});
 				this.server.memoryFs.addBuffer(path, content);
 				this.server.refreshFileEvent.send(path);
+			},
+			{noRetry: true},
+		);
+	}
+
+	async requestWorkerPatchBuffer(
+		path: AbsoluteFilePath,
+		patches: Array<WorkerBufferPatch>,
+	): Promise<string> {
+		this.checkCancelled();
+
+		return this.wrapRequestDiagnostic(
+			"patchBuffer",
+			path,
+			async (bridge, file) => {
+				const buffer = await bridge.patchBuffer.call({file, patches});
+				this.server.memoryFs.addBuffer(path, buffer);
+				this.server.refreshFileEvent.send(path);
+				return buffer;
 			},
 			{noRetry: true},
 		);

--- a/packages/@romefrontend/core/server/lsp/utils.ts
+++ b/packages/@romefrontend/core/server/lsp/utils.ts
@@ -13,6 +13,7 @@ import {Number0, ob1Coerce1To0, ob1Inc, ob1Number0} from "@romefrontend/ob1";
 import {Position} from "@romefrontend/parser-core";
 import {DiagnosticLocation, Diagnostics} from "@romefrontend/diagnostics";
 import {Server} from "@romefrontend/core";
+import {WorkerBufferPatch} from "@romefrontend/core/common/bridges/WorkerBridge";
 
 export function convertPositionToLSP(pos: undefined | Position): LSPPosition {
 	if (pos === undefined) {
@@ -152,4 +153,27 @@ export function diffTextEdits(
 	}
 
 	return edits;
+}
+
+export function getWorkerBufferPatches(
+	contentChanges: Consumer,
+): Array<WorkerBufferPatch> {
+	return contentChanges.asArray().map((change) => {
+		const start = change.get("range").get("start");
+		const end = change.get("range").get("end");
+
+		return {
+			text: change.get("text").asString(),
+			range: {
+				start: {
+					line: start.get("line").asZeroIndexedNumber(),
+					character: start.get("character").asZeroIndexedNumber(),
+				},
+				end: {
+					line: end.get("line").asZeroIndexedNumber(),
+					character: end.get("character").asZeroIndexedNumber(),
+				},
+			},
+		};
+	});
 }

--- a/packages/@romefrontend/core/worker/utils/applyWorkerBufferPatch.test.ts
+++ b/packages/@romefrontend/core/worker/utils/applyWorkerBufferPatch.test.ts
@@ -1,0 +1,167 @@
+import {test} from "rome";
+import {applyWorkerBufferPatch} from "./applyWorkerBufferPatch";
+import {WorkerBufferPatch} from "@romefrontend/core/common/bridges/WorkerBridge";
+import {ob1Coerce0} from "@romefrontend/ob1";
+import {dedent} from "@romefrontend/string-utils";
+
+function makeRange(
+	startLine: number,
+	startChar: number,
+	endLine: number,
+	endChar: number,
+) {
+	return {
+		start: {
+			line: ob1Coerce0(startLine),
+			character: ob1Coerce0(startChar),
+		},
+		end: {
+			line: ob1Coerce0(endLine),
+			character: ob1Coerce0(endChar),
+		},
+	};
+}
+
+test(
+	"applyWorkerBufferPatch can insert text",
+	async (t) => {
+		const original = "this is a test";
+		const patch = {
+			range: makeRange(0, 10, 0, 10),
+			text: "patch ",
+		};
+
+		t.inlineSnapshot(
+			applyWorkerBufferPatch(original, patch),
+			"this is a patch test",
+		);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch can append text",
+	async (t) => {
+		const original = "rome";
+		const patch: WorkerBufferPatch = {
+			range: makeRange(0, 4, 0, 4),
+			text: "\nfoo",
+		};
+
+		t.inlineSnapshot(applyWorkerBufferPatch(original, patch), "rome\nfoo");
+	},
+);
+
+test(
+	"applyWorkerBufferPatch handles characters represented by two code units",
+	async (t) => {
+		const original = dedent`
+			test
+			a𐐀b
+			rome
+		`;
+		const patch: WorkerBufferPatch = {
+			range: makeRange(1, 3, 1, 4),
+			text: "foo",
+		};
+
+		t.inlineSnapshot(
+			applyWorkerBufferPatch(original, patch),
+			"test\na\u{10400}foo\nrome",
+		);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch can patch multiline text",
+	async (t) => {
+		const original = dedent`
+			let foo = "test";
+			foo = "wrong";
+			console.log(foo);
+		`;
+		const patch = {
+			range: makeRange(0, 11, 1, 12),
+			text: "right",
+		};
+
+		t.inlineSnapshot(
+			applyWorkerBufferPatch(original, patch),
+			'let foo = "right";\nconsole.log(foo);',
+		);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch can delete a line",
+	async (t) => {
+		const original = dedent`
+			let foo = "test";
+			foo = "wrong";
+			console.log(foo);
+		`;
+		const patch = {
+			range: makeRange(1, 0, 2, 0),
+			text: "",
+		};
+
+		t.inlineSnapshot(
+			applyWorkerBufferPatch(original, patch),
+			'let foo = "test";\nconsole.log(foo);',
+		);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch handles all end-of-line sequences",
+	async (t) => {
+		const original = "zero\none\r\ntwo\rthree\r\nfour\nfive";
+		const patch = {
+			range: makeRange(4, 0, 4, 4),
+			text: "FOUR",
+		};
+
+		t.inlineSnapshot(
+			applyWorkerBufferPatch(original, patch),
+			"zero\none\r\ntwo\rthree\r\nFOUR\nfive",
+		);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch returns undefined for start > end",
+	async (t) => {
+		const original = "test";
+		const patch = {
+			range: makeRange(2, 0, 1, 0),
+			text: "wrong",
+		};
+
+		t.is(applyWorkerBufferPatch(original, patch), undefined);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch returns undefined for unfound start position",
+	async (t) => {
+		const original = "zero\none\ntwo\nthree";
+		const patch = {
+			range: makeRange(1, 99, 2, 0),
+			text: "wrong",
+		};
+
+		t.is(applyWorkerBufferPatch(original, patch), undefined);
+	},
+);
+
+test(
+	"applyWorkerBufferPatch returns undefined for unfound end position",
+	async (t) => {
+		const original = "zero\none\ntwo\nthree";
+		const patch = {
+			range: makeRange(2, 0, 2, 99),
+			text: "wrong",
+		};
+
+		t.is(applyWorkerBufferPatch(original, patch), undefined);
+	},
+);

--- a/packages/@romefrontend/core/worker/utils/applyWorkerBufferPatch.ts
+++ b/packages/@romefrontend/core/worker/utils/applyWorkerBufferPatch.ts
@@ -1,0 +1,61 @@
+import {Number0, ob1Get0, ob1Inc, ob1Number0} from "@romefrontend/ob1";
+import {WorkerBufferPatch} from "@romefrontend/core/common/bridges/WorkerBridge";
+
+export function applyWorkerBufferPatch(
+	original: string,
+	{range: {start, end}, text}: WorkerBufferPatch,
+) {
+	let currLine: Number0 = ob1Number0;
+	let currChar: Number0 = ob1Number0;
+	let cursor: Number0 = ob1Number0;
+
+	let buffer: string | undefined;
+
+	// Offset based on UTF-16 code units
+	while (ob1Get0(cursor) <= original.length) {
+		// Start position
+		if (currLine === start.line && currChar === start.character) {
+			// Include anything before the start of the patch range
+			const preText = original.slice(0, ob1Get0(cursor));
+			buffer = preText + text;
+		}
+
+		// End position
+		if (currLine === end.line && currChar === end.character) {
+			if (buffer === undefined) {
+				// Start position was not encountered
+				return undefined;
+			}
+			// Append anything after the end of the patch range
+			const postText = original.slice(ob1Get0(cursor));
+			buffer += postText;
+			return buffer;
+		}
+
+		switch (original[ob1Get0(cursor)]) {
+			case "\n": {
+				currLine = ob1Inc(currLine);
+				currChar = ob1Number0;
+				break;
+			}
+			case "\r": {
+				currLine = ob1Inc(currLine);
+				currChar = ob1Number0;
+
+				//  \r\n should only advance 1 line
+				if (original[ob1Get0(cursor) + 1] === "\n") {
+					cursor = ob1Inc(cursor);
+				}
+				break;
+			}
+			default: {
+				currChar = ob1Inc(currChar);
+			}
+		}
+
+		cursor = ob1Inc(cursor);
+	}
+
+	// End position was not encountered
+	return undefined;
+}


### PR DESCRIPTION
This PR adds incremental `textDocument` syncing to `LSPServer` by adding buffer patching capabilities to workers.

I added a `WorkerBufferPatch` type that resembles the LSP `TextDocumentContentChangeEvent` because I didn't want to use LSP-specific types in `Worker`.

Currently, `patchBuffer` returns the entire buffer over the `WorkerBridge` so that it can be passed to `memoryFs.addBuffer()` and also returned by `requestWorkerPatchBuffer`

If we don't think we'll need the return value, it might make sense to change `MemoryFileSystem#addBuffer` to accept a `size` instead of `content` and then we can just return the new size from `Worker#patchBuffer`

The `applyWorkerBufferPatch` utility handles unicode characters according to the LSP spec (I think) but the LSP server still has a formatting problem that I'll follow up on.