### PR TITLE
Buffer server logs before first connected client

### DIFF
--- a/packages/@romefrontend/cli/cli.ts
+++ b/packages/@romefrontend/cli/cli.ts
@@ -28,7 +28,7 @@ import {
 import {commandCategories} from "@romefrontend/core/common/commands";
 import {writeFile} from "@romefrontend/fs";
 import fs = require("fs");
-import {markup} from "@romefrontend/string-markup";
+import {markup, markupToPlainTextString} from "@romefrontend/string-markup";
 import {JSONObject, stringifyJSON} from "@romefrontend/codec-json";
 import {getEnvVar} from "@romefrontend/environment";
 
@@ -458,13 +458,13 @@ export default async function cli() {
 				});
 			}
 
-			await client.subscribeLogs(
+			client.subscribeLogs(
 				cliFlags.logWorkers === true,
 				(chunk) => {
 					if (fileout === undefined) {
-						client.reporter.writeAll(chunk);
+						client.reporter.logAll(chunk, {newline: false});
 					} else {
-						fileout.write(chunk);
+						fileout.write(markupToPlainTextString(chunk));
 					}
 				},
 			);

--- a/packages/@romefrontend/core/common/utils/Logger.ts
+++ b/packages/@romefrontend/core/common/utils/Logger.ts
@@ -10,20 +10,11 @@ import {
 	ReporterConditionalStream,
 	ReporterOptions,
 } from "@romefrontend/cli-reporter";
-import {AbsoluteFilePath} from "@romefrontend/path";
 import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/environment";
-
-export type LoggerOptions = {
-	cwd?: AbsoluteFilePath;
-	excludePid?: boolean;
-	type: string;
-};
-
-export type PartialLoggerOptions = Partial<LoggerOptions>;
 
 export default class Logger extends Reporter {
 	constructor(
-		loggerOptions: LoggerOptions,
+		loggerType: string,
 		opts: ReporterOptions,
 		{write, check}: {
 			check: () => boolean;
@@ -33,17 +24,13 @@ export default class Logger extends Reporter {
 		super({
 			verbose: true,
 			...opts,
-			markupOptions: {
-				cwd: loggerOptions.cwd,
-				...opts.markupOptions,
-			},
 		});
-		this.loggerOptions = loggerOptions;
+		this.loggerType = loggerType;
 
 		this.conditionalStream = this.attachConditionalStream(
 			{
 				type: "all",
-				format: "none",
+				format: "markup",
 				features: {
 					...TERMINAL_FEATURES_DEFAULT,
 					columns: Infinity,
@@ -55,17 +42,15 @@ export default class Logger extends Reporter {
 	}
 
 	conditionalStream: ReporterConditionalStream;
-	loggerOptions: LoggerOptions;
+	loggerType: string;
 
 	updateStream() {
 		this.conditionalStream.update();
 	}
 
-	_getMessagePrefix() {
-		let inner = this.loggerOptions.type;
-		if (!this.loggerOptions.excludePid) {
-			inner += ` ${process.pid}`;
-		}
-		return `<dim>[${inner}]</dim> `;
+	getMessagePrefix() {
+		const inner = `${this.loggerType} ${process.pid}`;
+		const timestamp = new Date().toISOString();
+		return `<dim>[${timestamp}] [${inner}]</dim> `;
 	}
 }

--- a/packages/@romefrontend/core/integrationTestHelpers.ts
+++ b/packages/@romefrontend/core/integrationTestHelpers.ts
@@ -162,11 +162,6 @@ export function createIntegrationTest(
 					// Force cache to be enabled (which will be at our generated folder specified above)
 					// This will ignore any ROME_CACHE env variable specified by scripts/dev-rome
 					forceCacheEnabled: true,
-					// Custom loggerOptions so that logs don't vary between runs. ie. relative paths and no PIDs
-					loggerOptions: {
-						cwd: temp,
-						excludePid: true,
-					},
 					userConfig,
 				});
 

--- a/packages/@romefrontend/core/server/ServerReporter.ts
+++ b/packages/@romefrontend/core/server/ServerReporter.ts
@@ -23,9 +23,16 @@ export default class ServerReporter extends Reporter {
 
 	server: Server;
 
-	// This is so all progress bars are also shown on an LSP client, alongside connected CLIs
+	// This is so all progress bars are renderer on each client. If we just use this.progressLocal then
+	// while it would work, we would be doing all the rendering work on the server
+	// The CLI also needs to know all the activeElements so it can properly draw and clear lines
+	// We also create a progress bar for all connected LSP clients
 	progress(opts?: ReporterProgressOptions): ReporterProgress {
-		const progresses: Array<ReporterProgress> = [this.progressLocal(opts)];
+		const progresses: Array<ReporterProgress> = [];
+
+		for (const client of this.server.connectedClients) {
+			progresses.push(client.reporter.progress(opts));
+		}
 
 		for (const server of this.server.connectedLSPServers) {
 			progresses.push(server.createProgress(opts));

--- a/packages/@romefrontend/core/server/ServerRequest.ts
+++ b/packages/@romefrontend/core/server/ServerRequest.ts
@@ -819,7 +819,9 @@ export default class ServerRequest {
 	startMarker(
 		opts: Omit<ServerUnfinishedMarker, "start">,
 	): ServerUnfinishedMarker {
-		this.server.logger.info("[ServerRequest] Started marker", opts.label);
+		this.server.logger.info(
+			markup`[ServerRequest] Started marker: ${opts.label}`,
+		);
 		return {
 			...opts,
 			start: Date.now(),
@@ -832,8 +834,7 @@ export default class ServerRequest {
 			end: Date.now(),
 		};
 		this.server.logger.info(
-			"[ServerRequest] Finished marker",
-			startMarker.label,
+			markup`[ServerRequest] Started marker: ${startMarker.label}`,
 		);
 		this.markerEvent.send(endMarker);
 		return endMarker;

--- a/packages/@romefrontend/core/server/WorkerManager.ts
+++ b/packages/@romefrontend/core/server/WorkerManager.ts
@@ -131,14 +131,12 @@ export default class WorkerManager {
 		// Create the worker
 		const bridge = createBridgeFromLocal(WorkerBridge, {});
 		const worker = new Worker({
-			loggerOptions: this.server.logger.loggerOptions,
 			userConfig: this.server.userConfig,
 			bridge,
 			globalErrorHandlers: false,
 		});
 
 		// We make an assumption elsewhere in the code that this is always the first worker
-
 		// Let's use an invariant here for completeness
 		const id = this.getNextWorkerId();
 		if (id !== 0) {

--- a/packages/@romefrontend/core/server/fs/FileAllocator.ts
+++ b/packages/@romefrontend/core/server/fs/FileAllocator.ts
@@ -156,7 +156,7 @@ export default class FileAllocator {
 	}
 
 	async assignOwner(path: AbsoluteFilePath): Promise<WorkerContainer> {
-		const {workerManager, logger} = this.server;
+		const {workerManager, logger, memoryFs} = this.server;
 
 		const lock = await this.locker.getLock(path);
 
@@ -165,14 +165,15 @@ export default class FileAllocator {
 			lock.release();
 			return this.getOwnerAssert(path);
 		}
+
 		try {
 			const worker = await workerManager.getNextWorker(path);
 
 			// Add ourselves to the file map
 			logger.info(
-				"[FileAllocator] File %s assigned to worker %s",
-				path.toMarkup(),
-				worker.id,
+				`[FileAllocator] File <emphasis>${path.toMarkup()}</emphasis> (file size <filesize>${memoryFs.getFileStats(
+					path,
+				)?.size}</filesize>) assigned to worker <number>${worker.id}</number>`,
 			);
 			this.fileToWorker.set(path, worker.id);
 

--- a/packages/@romefrontend/core/server/fs/MemoryFileSystem.ts
+++ b/packages/@romefrontend/core/server/fs/MemoryFileSystem.ts
@@ -28,7 +28,6 @@ import {
 } from "@romefrontend/diagnostics";
 import {Event} from "@romefrontend/events";
 import {consumeJSON} from "@romefrontend/codec-json";
-import {humanizeNumber} from "@romefrontend/string-utils";
 import {WorkerPartialManifest} from "../../common/bridges/WorkerBridge";
 import {
 	AbsoluteFilePath,
@@ -43,7 +42,6 @@ import {
 	watch,
 } from "@romefrontend/fs";
 import {getFileHandler} from "../../common/file-handlers/index";
-import {markup} from "@romefrontend/string-markup";
 import crypto = require("crypto");
 import fs = require("fs");
 import {FileNotFound} from "@romefrontend/core/common/FileNotFound";
@@ -145,11 +143,12 @@ async function createWatcher(
 	projectFolder: AbsoluteFilePath,
 ): Promise<WatcherClose> {
 	const {logger} = memoryFs.server;
+	const projectFolderMarkup = "<emphasis>projectFolder.toMarkup()</emphasis>";
 
 	// Create activity spinners for all connected reporters
 	const activity = memoryFs.server.connectedReporters.progress({
 		initDelay: 1_000,
-		title: `Adding project ${projectFolder.toMarkup()}`,
+		title: `Adding project ${projectFolderMarkup}`,
 	});
 
 	const watchers: AbsoluteFilePathMap<fs.FSWatcher> = new AbsoluteFilePathMap();
@@ -175,7 +174,7 @@ async function createWatcher(
 				{recursive, persistent: false},
 				(eventType, filename) => {
 					memoryFs.server.logger.info(
-						`[MemoryFileSystem] Raw fs.watch event in ${folderPath.toMarkup()} type ${eventType} for ${filename}`,
+						`[MemoryFileSystem] Raw fs.watch event in <emphasis>${folderPath.toMarkup()}</emphasis> type ${eventType} for ${filename}`,
 					);
 
 					if (filename === null) {
@@ -207,9 +206,9 @@ async function createWatcher(
 			},
 		);
 		logger.info(
-			`[MemoryFileSystem] Finished initial crawl for ${projectFolder.toMarkup()} - added ${humanizeNumber(
-				memoryFs.countFiles(projectFolder),
-			)} files`,
+			`[MemoryFileSystem] Finished initial crawl for <emphasis>${projectFolder.toMarkup()}</emphasis> - added <number>${memoryFs.countFiles(
+				projectFolder,
+			)}</number> files`,
 		);
 	} finally {
 		activity.end();
@@ -456,8 +455,7 @@ export default class MemoryFileSystem {
 
 	async watch(projectFolder: AbsoluteFilePath): Promise<void> {
 		const {logger} = this.server;
-		const projectFolderJoined = projectFolder.join();
-		const folderLink = markup`<filelink target="${projectFolderJoined}" />`;
+		const folderLink = `<emphasis>${projectFolder.toMarkup()}</emphasis>`;
 
 		// Defer if we're already currently initializing this project
 		const cached = this.watchPromises.get(projectFolder);
@@ -962,8 +960,7 @@ export default class MemoryFileSystem {
 		const oldStats = this.getFileStats(path);
 		if (oldStats !== undefined && opts.reason === "watch") {
 			this.server.logger.info(
-				"[MemoryFileSystem] File change:",
-				path.toMarkup(),
+				`[MemoryFileSystem] File change: <emphasis>${path.toMarkup()}</emphasis>`,
 			);
 			this.server.refreshFileEvent.send(path);
 			this.changedFileEvent.send({path, oldStats, newStats: stats});

--- a/packages/@romefrontend/core/server/lsp/protocol.test.md
+++ b/packages/@romefrontend/core/server/lsp/protocol.test.md
@@ -17,6 +17,7 @@
   t handle this comment
   const foo = 'Or this “special” string';
   const rocket = "Or this🚀";
+
   rocket;
   foo;"}]}}
 ℹ [LSPServer][Transport] Status: IDLE

--- a/packages/@romefrontend/core/worker/Worker.ts
+++ b/packages/@romefrontend/core/worker/Worker.ts
@@ -15,9 +15,8 @@ import WorkerBridge, {
 	WorkerProjects,
 } from "../common/bridges/WorkerBridge";
 import {AnyRoot, ConstJSSourceType, JSRoot} from "@romefrontend/ast";
-import Logger, {PartialLoggerOptions} from "../common/utils/Logger";
+import Logger from "../common/utils/Logger";
 import {Profiler} from "@romefrontend/v8";
-
 import setupGlobalErrorHandlers from "../common/utils/setupGlobalErrorHandlers";
 import {UserConfig, loadUserConfig} from "../common/userConfig";
 import {hydrateJSONProjectConfig} from "@romefrontend/project";
@@ -50,7 +49,6 @@ export type ParseResult = {
 };
 
 type WorkerOptions = {
-	loggerOptions?: PartialLoggerOptions;
 	userConfig?: UserConfig;
 	globalErrorHandlers: boolean;
 	bridge: WorkerBridge;
@@ -69,10 +67,7 @@ export default class Worker {
 		this.buffers = new AbsoluteFilePathMap();
 
 		this.logger = new Logger(
-			{
-				...opts.loggerOptions,
-				type: "worker",
-			},
+			"worker",
 			{},
 			{
 				check: () => opts.bridge.log.hasSubscribers(),

--- a/packages/@romefrontend/string-markup/format.ts
+++ b/packages/@romefrontend/string-markup/format.ts
@@ -135,7 +135,7 @@ function renderGrid(
 		...opts,
 		sourceText: input,
 	});
-	grid.drawRoot(parseMarkup(input));
+	grid.drawChildren(grid.parse(input, undefined), []);
 	return {
 		width: ob1Get1(grid.getWidth()),
 		lines: grid.getLines(format),


### PR DESCRIPTION
This PR does the following:

 - Server logs are now buffered until the first connected client. After that we stop buffering logs. When a client connects and enables logs then we send the init buffer. This is cheap for us to buffer because we do so little during init before a client connects. We can put some critical debug information in there.
 - Server/workers now send logs in raw markup. It's then up to the client to decide if they want to format or strip it. This allows `--logs` when ran in the terminal to have colors!