### PR TITLE
Split up view tags, add custom indentation gutter, and custom additional soft line indentation

### DIFF
--- a/packages/@romefrontend/compiler/lint/rules/js/noDuplicateGroupNamesInRegularExpressions.test.md
+++ b/packages/@romefrontend/compiler/lint/rules/js/noDuplicateGroupNamesInRegularExpressions.test.md
@@ -13,15 +13,15 @@
   ✖ Avoid duplicate group names. Check the month group.
 
     /(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>
-    [0-9])/
+      [0-9])/
 
   ℹ Defined already here
 
     /(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>
-    [0-9])/
+      [0-9])/
 
     /(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>
-    [0-9])/
+      [0-9])/
     ^^^^^
 
  unknown:1:17 lint/js/noDuplicateGroupNamesInRegularExpressions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -29,12 +29,12 @@
   ✖ Avoid duplicate group names. Check the year group.
 
     /(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>
-    [0-9])/
+      [0-9])/
 
   ℹ Defined already here
 
     /(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>
-    [0-9])/
+      [0-9])/
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romefrontend/compiler/lint/rules/react/noDangerWithChildren.test.md
+++ b/packages/@romefrontend/compiler/lint/rules/react/noDangerWithChildren.test.md
@@ -207,7 +207,7 @@ React.createElement(
   ✖ Avoid passing both children and the dangerouslySetInnerHTML prop.
 
     React.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" }, children: "children"
-     })
+       })
     ^^^^^^^^^^^
 
   ℹ Setting HTML content will inadvertently override any passed children in React.
@@ -497,7 +497,7 @@ createElement(
   ✖ Avoid passing both children and the dangerouslySetInnerHTML prop.
 
     createElement("Invalid", { dangerouslySetInnerHTML: { __html: "HTML" }, children: "children" }
-    )
+      )
     ^^^^^^^^^^
 
   ℹ Setting HTML content will inadvertently override any passed children in React.
@@ -527,7 +527,7 @@ createElement(
   ✖ Avoid passing both children and the dangerouslySetInnerHTML prop.
 
     createElement("Invalid", { dangerouslySetInnerHTML: { __html: "HTML" }, children: ["children"]
-     })
+       })
     ^^^^^^^^^^^
 
   ℹ Setting HTML content will inadvertently override any passed children in React.

--- a/packages/@romefrontend/core/client/Client.ts
+++ b/packages/@romefrontend/core/client/Client.ts
@@ -457,6 +457,11 @@ export default class Client {
 	}
 
 	async shutdownServer() {
+		await this._shutdownServer();
+		await this.end();
+	}
+
+	async _shutdownServer() {
 		const status = this.bridgeStatus;
 		if (status !== undefined && status.bridge.alive) {
 			try {
@@ -469,8 +474,6 @@ export default class Client {
 				}
 			}
 		}
-
-		await this.end();
 	}
 
 	async end() {
@@ -481,7 +484,7 @@ export default class Client {
 			if (status.dedicated) {
 				status.socket.end();
 			} else {
-				await this.shutdownServer();
+				await this._shutdownServer();
 			}
 		}
 

--- a/packages/@romefrontend/core/server/fs/MemoryFileSystem.ts
+++ b/packages/@romefrontend/core/server/fs/MemoryFileSystem.ts
@@ -143,7 +143,7 @@ async function createWatcher(
 	projectFolder: AbsoluteFilePath,
 ): Promise<WatcherClose> {
 	const {logger} = memoryFs.server;
-	const projectFolderMarkup = "<emphasis>projectFolder.toMarkup()</emphasis>";
+	const projectFolderMarkup = `<emphasis>${projectFolder.toMarkup()}</emphasis>`;
 
 	// Create activity spinners for all connected reporters
 	const activity = memoryFs.server.connectedReporters.progress({

--- a/packages/@romefrontend/core/server/lsp/protocol.test.md
+++ b/packages/@romefrontend/core/server/lsp/protocol.test.md
@@ -17,7 +17,7 @@
   t handle this comment
   const foo = 'Or this “special” string';
   const rocket = "Or this🚀";
-
+  
   rocket;
   foo;"}]}}
 ℹ [LSPServer][Transport] Status: IDLE

--- a/packages/@romefrontend/diagnostics/errors.ts
+++ b/packages/@romefrontend/diagnostics/errors.ts
@@ -45,7 +45,7 @@ export class DiagnosticsError extends Error {
 			return [
 				"Possible DiagnosticsError message serialization infinite loop",
 				"Diagnostic messages:",
-				this.diagnostics.map((diag) => `- ${diag.description.message}`),
+				this.diagnostics.map((diag) => `- ${diag.description.message.value}`),
 			].join("\n");
 		}
 

--- a/packages/@romefrontend/string-markup/escape.ts
+++ b/packages/@romefrontend/string-markup/escape.ts
@@ -54,6 +54,8 @@ export function escapeMarkup(input: string): string {
 
 		if (char === "<") {
 			escaped += "\\<";
+		} else if (char === '"') {
+			escaped += '\\"';
 		} else if (char === "\\") {
 			escaped += "\\\\";
 		} else {
@@ -94,7 +96,7 @@ export function unescapeTextValue(str: string): string {
 		// Unescape \\\\ to just \\
 		if (char === "\\") {
 			const nextChar = str[i + 1];
-			if (nextChar === "<" || nextChar === "\\") {
+			if (nextChar === "<" || nextChar === '"' || nextChar === "\\") {
 				i++;
 				unescaped += nextChar;
 				continue;

--- a/packages/@romefrontend/string-markup/format.test.md
+++ b/packages/@romefrontend/string-markup/format.test.md
@@ -8,7 +8,7 @@
 
  unknown parse/stringMarkup ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Expected token Greater but got EOF
+  ✖ pointerChar is not a valid attribute name for view
 
     <view pointerChar="<emphasis" pointerLine="1" pointerStart="1" pointerEnd="3">foobar</view>
 

--- a/packages/@romefrontend/string-markup/format.ts
+++ b/packages/@romefrontend/string-markup/format.ts
@@ -134,6 +134,7 @@ function renderGrid(
 	const grid = new Grid({
 		...opts,
 		sourceText: input,
+		view: {},
 	});
 	grid.drawChildren(grid.parse(input, undefined), []);
 	return {

--- a/packages/@romefrontend/string-markup/tags.ts
+++ b/packages/@romefrontend/string-markup/tags.ts
@@ -25,7 +25,7 @@ const booleanValidator: AttributeValidator = (value, key) => {
 	return undefined;
 };
 const numberValidator: AttributeValidator = (value) => {
-	const num = Number(value);
+	const num = parseFloat(value);
 	if (isNaN(num)) {
 		return undefined;
 	} else {
@@ -53,13 +53,22 @@ tags.set(
 tags.set(
 	"view",
 	new Map([
-		["linePrefix", stringValidator],
-		["pointerMessage", stringValidator],
-		["pointerLine", numberValidator],
-		["pointerStart", numberValidator],
-		["pointerEnd", numberValidator],
-		["pointerChar", stringValidator],
+		["extraSoftWrapIndent", numberValidator],
 		["lineWrap", lineWrapValidator],
+		["align", alignValidator],
+	]),
+);
+tags.set(
+	"viewLinePrefix",
+	new Map([["type", stringValidator], ["align", alignValidator]]),
+);
+tags.set(
+	"viewPointer",
+	new Map([
+		["char", stringValidator],
+		["line", numberValidator],
+		["start", numberValidator],
+		["end", numberValidator],
 	]),
 );
 tags.set(
@@ -99,11 +108,11 @@ tags.set(
 );
 tags.set("table", new Map());
 tags.set("tr", new Map());
-tags.set("td", new Map([["align", stringValidator]]));
+tags.set("td", new Map([["align", alignValidator]]));
 tags.set("hr", new Map());
 tags.set(
 	"pad",
-	new Map([["width", numberValidator], ["align", stringValidator]]),
+	new Map([["width", numberValidator], ["align", alignValidator]]),
 );
 tags.set("nobr", new Map());
 tags.set("li", new Map());
@@ -125,6 +134,16 @@ export const tagsToOnlyParent: Map<MarkupTagName, Array<MarkupTagName>> = new Ma
 tagsToOnlyParent.set("tr", ["table"]);
 tagsToOnlyParent.set("td", ["tr"]);
 tagsToOnlyParent.set("li", ["ol", "ul"]);
+tagsToOnlyParent.set("viewLinePrefix", ["view"]);
+tagsToOnlyParent.set("viewPointer", ["view"]);
+
+function alignValidator(align: undefined | string): undefined | string {
+	if (align === "left" || align === "right") {
+		return align;
+	}
+
+	return undefined;
+}
 
 // Validators
 export function lineWrapValidator(

--- a/packages/@romefrontend/string-markup/types.ts
+++ b/packages/@romefrontend/string-markup/types.ts
@@ -47,6 +47,8 @@ export type Children = Array<ChildNode>;
 
 export type MarkupTagName =
 	| "view"
+	| "viewLinePrefix"
+	| "viewPointer"
 	| "token"
 	| "hr"
 	| "pad"
@@ -111,10 +113,15 @@ export type UserMarkupFormatGridOptions = MarkupFormatOptions & {
 	columns?: number;
 };
 
-export type MarkupFormatGridOptions = UserMarkupFormatGridOptions & {
-	sourceText: string;
+export type MarkupGridViewOptions = {
+	extraSoftWrapIndent?: number;
 	lineWrapMode?: MarkupLineWrapMode;
 	pointer?: MarkupPointer;
+};
+
+export type MarkupFormatGridOptions = UserMarkupFormatGridOptions & {
+	sourceText: string;
+	view: MarkupGridViewOptions;
 };
 
 export type MarkupFormatNormalizeOptions = MarkupFormatOptions & {


### PR DESCRIPTION
This is now how the code frames look.

**Path**

<img width="1776" alt="Screen Shot 2020-07-12 at 2 50 11 PM" src="https://user-images.githubusercontent.com/853712/87257479-28d99f80-c450-11ea-8db4-3050fcff1fdf.png">


**Pointer/Message**

<img width="1776" alt="Screen Shot 2020-07-12 at 2 50 26 PM" src="https://user-images.githubusercontent.com/853712/87257476-25deaf00-c450-11ea-9f5f-057692ac67ca.png">
