### PR TITLE
rage and logs command polish

### DIFF
--- a/packages/@romefrontend/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/packages/@romefrontend/cli-diagnostics/DiagnosticsPrinter.ts
@@ -24,7 +24,7 @@ import {
 import {
 	formatAnsi,
 	markup,
-	markupToPlainTextString,
+	markupToPlainText,
 } from "@romefrontend/string-markup";
 import {ToLines, toLines} from "./utils";
 import {printAdvice} from "./printAdvice";
@@ -41,6 +41,7 @@ import {
 } from "@romefrontend/path";
 import {Number0, Number1, ob1Get0, ob1Get1} from "@romefrontend/ob1";
 import {existsSync, lstatSync, readFileTextSync} from "@romefrontend/fs";
+import {joinMarkupLines} from "@romefrontend/string-markup/format";
 
 type Banner = {
 	// Array<number> should really be [number, number, number], but TypeScript widens the imported types
@@ -222,7 +223,7 @@ export default class DiagnosticsPrinter extends Error {
 
 		// Match against the supplied grep pattern
 		let ignored =
-			markupToPlainTextString(diag.description.message.value).toLowerCase().includes(
+			joinMarkupLines(markupToPlainText(diag.description.message.value)).toLowerCase().includes(
 				grep,
 			) === false;
 		if (inverseGrep) {
@@ -442,8 +443,8 @@ export default class DiagnosticsPrinter extends Error {
 					}
 				}
 
-				let log = `::error ${parts.join(",")}::${markupToPlainTextString(
-					message.value,
+				let log = `::error ${parts.join(",")}::${joinMarkupLines(
+					markupToPlainText(message.value),
 				)}`;
 				this.reporter.logAllRaw(log);
 				break;

--- a/packages/@romefrontend/cli-diagnostics/buildCodeFrame.ts
+++ b/packages/@romefrontend/cli-diagnostics/buildCodeFrame.ts
@@ -25,8 +25,9 @@ import {
 	ob1Number0,
 	ob1Number1Neg1,
 } from "@romefrontend/ob1";
-import {markupTag, markupToPlainTextString} from "@romefrontend/string-markup";
+import {markupTag, markupToPlainText} from "@romefrontend/string-markup";
 import {Dict} from "@romefrontend/typescript-helpers";
+import {joinMarkupLines} from "@romefrontend/string-markup/format";
 
 type Marker = {
 	message: string;
@@ -251,7 +252,7 @@ export default function buildCodeFrame(
 		const text = sourceText.slice(ob1Get0(start.index), ob1Get0(end.index));
 		if (
 			cleanEquivalentString(text) ===
-			cleanEquivalentString(markupToPlainTextString(markerMessage))
+			cleanEquivalentString(joinMarkupLines(markupToPlainText(markerMessage)))
 		) {
 			markerMessage = "";
 		}

--- a/packages/@romefrontend/cli-diagnostics/buildPatchCodeFrame.test.ts
+++ b/packages/@romefrontend/cli-diagnostics/buildPatchCodeFrame.test.ts
@@ -1,8 +1,9 @@
 import {test} from "rome";
 import buildPatchCodeFrame from "./buildPatchCodeFrame";
 import stringDiff from "@romefrontend/string-diff";
-import {markupToPlainTextString} from "@romefrontend/string-markup";
+import {markupToPlainText} from "@romefrontend/string-markup";
 import {dedent} from "@romefrontend/string-utils";
+import {joinMarkupLines} from "@romefrontend/string-markup/format";
 
 type Test = {
 	before: string;
@@ -136,14 +137,16 @@ test(
 			lines.push("");
 			lines.push("# Diff");
 			lines.push(
-				markupToPlainTextString(
-					buildPatchCodeFrame(
-						{
-							type: "diff",
-							diff: stringDiff(before, after),
-						},
-						true,
-					).frame,
+				joinMarkupLines(
+					markupToPlainText(
+						buildPatchCodeFrame(
+							{
+								type: "diff",
+								diff: stringDiff(before, after),
+							},
+							true,
+						).frame,
+					),
 				),
 			);
 			t.snapshot(lines.join("\n"));

--- a/packages/@romefrontend/cli-diagnostics/utils.ts
+++ b/packages/@romefrontend/cli-diagnostics/utils.ts
@@ -5,10 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {markupToPlainTextString} from "@romefrontend/string-markup";
 import highlightCode, {AnsiHighlightOptions} from "./highlightCode";
 import {NEWLINE, nonASCIIwhitespace} from "@romefrontend/js-parser-utils";
 import {removeCarriageReturn} from "@romefrontend/string-utils";
+import {
+	joinMarkupLines,
+	markupToPlainText,
+} from "@romefrontend/string-markup/format";
 
 const unicodeControls = /[\u0000-\u001f\u007f-\u00a0]/u;
 
@@ -133,7 +136,7 @@ function showInvisibleChar(char: string): undefined | string {
 }
 
 export function cleanEquivalentString(str: string): string {
-	str = markupToPlainTextString(str);
+	str = joinMarkupLines(markupToPlainText(str));
 
 	// Replace all whitespace with spaces
 	str = str.replace(/[\s\n]+/g, " ");

--- a/packages/@romefrontend/cli/bin/rome.ts
+++ b/packages/@romefrontend/cli/bin/rome.ts
@@ -40,7 +40,15 @@ async function main(): Promise<void> {
 	}
 }
 
+setInterval(
+	() => {
+		// We want to exit on our own terms
+	},
+	1_000_000,
+);
+
 initErrorHooks();
+
 sourceMapManager.add(
 	BIN.join(),
 	SourceMapConsumer.fromJSONLazy(

--- a/packages/@romefrontend/core/client/commands/lsp.ts
+++ b/packages/@romefrontend/core/client/commands/lsp.ts
@@ -26,7 +26,7 @@ export default createLocalCommand({
 		});
 
 		const stdin = req.client.reporter.getStdin();
-		req.client.reporter.teardown();
+		req.client.reporter.redirectOutToErr(true);
 
 		const bridge = await req.client.findOrStartServer();
 		if (bridge === undefined) {

--- a/packages/@romefrontend/core/common/bridges/ServerBridge.ts
+++ b/packages/@romefrontend/core/common/bridges/ServerBridge.ts
@@ -98,13 +98,8 @@ export default class ServerBridge extends Bridge {
 		direction: "server->client",
 	});
 
-	stdout = this.createEvent<string, void>({
-		name: "stdout",
-		direction: "server->client",
-	});
-
-	stderr = this.createEvent<string, void>({
-		name: "stderr",
+	write = this.createEvent<[string, boolean], void>({
+		name: "write",
 		direction: "server->client",
 	});
 

--- a/packages/@romefrontend/core/server/Server.ts
+++ b/packages/@romefrontend/core/server/Server.ts
@@ -646,12 +646,12 @@ export default class Server {
 
 				// Split up stdout chunks
 				if (chunk.length < STDOUT_MAX_CHUNK_LENGTH) {
-					bridge.stdout.send(chunk);
+					bridge.write.send([chunk, false]);
 				} else {
 					while (chunk.length > 0) {
 						const subChunk = chunk.slice(0, STDOUT_MAX_CHUNK_LENGTH);
 						chunk = chunk.slice(STDOUT_MAX_CHUNK_LENGTH);
-						bridge.stdout.send(subChunk);
+						bridge.write.send([subChunk, false]);
 					}
 				}
 			},
@@ -661,7 +661,7 @@ export default class Server {
 			...outStream,
 			type: "error",
 			write(chunk: string) {
-				bridge.stderr.send(chunk);
+				bridge.write.send([chunk, true]);
 			},
 		};
 

--- a/packages/@romefrontend/core/server/commands/noop.ts
+++ b/packages/@romefrontend/core/server/commands/noop.ts
@@ -9,15 +9,30 @@ import {ServerRequest} from "@romefrontend/core";
 import {commandCategories} from "../../common/commands";
 import {createServerCommand} from "../commands";
 
-export default createServerCommand({
+type Flags = {
+	hang: boolean;
+};
+
+export default createServerCommand<Flags>({
 	category: commandCategories.INTERNAL,
 	description: "TODO",
 	usage: "",
 	examples: [],
-	defineFlags() {
-		return {};
+	defineFlags(c) {
+		return {
+			hang: c.get("hang", {description: "Hang rather than instantly quitting"}).asBoolean(
+				false,
+			),
+		};
 	},
-	async callback(req: ServerRequest): Promise<void> {
-		req;
+	async callback(req: ServerRequest, flags: Flags): Promise<void> {
+		if (flags.hang) {
+			if (!req.server.options.dedicated) {
+				req.reporter.warn(
+					"Passed <emphasis>--hang</emphasis> flag but server not connected to a dedicated server so request will hang forever",
+				);
+			}
+			await req.endEvent.wait();
+		}
 	},
 });

--- a/packages/@romefrontend/core/server/lsp/LSPServer.ts
+++ b/packages/@romefrontend/core/server/lsp/LSPServer.ts
@@ -43,7 +43,6 @@ export default class LSPServer {
 
 		this.lintSessionsPending = new AbsoluteFilePathSet();
 		this.lintSessions = new AbsoluteFilePathMap();
-
 		this.fileBuffers = new AbsoluteFilePathSet();
 
 		request.endEvent.subscribe(async () => {
@@ -72,6 +71,7 @@ export default class LSPServer {
 	lintSessions: AbsoluteFilePathMap<ServerRequest>;
 
 	logMessage(path: AbsoluteFilePath, message: string) {
+		this.server.logger.info(`[LSPServer] ${message}`);
 		this.transport.write({
 			method: "window/logMessage",
 			params: {

--- a/packages/@romefrontend/core/server/lsp/protocol.test.md
+++ b/packages/@romefrontend/core/server/lsp/protocol.test.md
@@ -17,7 +17,7 @@
   t handle this comment
   const foo = 'Or this “special” string';
   const rocket = "Or this🚀";
-  
+
   rocket;
   foo;"}]}}
 ℹ [LSPServer][Transport] Status: IDLE

--- a/packages/@romefrontend/core/server/lsp/utils.ts
+++ b/packages/@romefrontend/core/server/lsp/utils.ts
@@ -1,4 +1,4 @@
-import {markupToPlainTextString} from "@romefrontend/string-markup";
+import {markupToPlainText} from "@romefrontend/string-markup";
 import {AbsoluteFilePath, createAbsoluteFilePath} from "@romefrontend/path";
 import {Consumer} from "@romefrontend/consume";
 import {
@@ -14,6 +14,7 @@ import {Position} from "@romefrontend/parser-core";
 import {DiagnosticLocation, Diagnostics} from "@romefrontend/diagnostics";
 import {Server} from "@romefrontend/core";
 import {WorkerBufferPatch} from "@romefrontend/core/common/bridges/WorkerBridge";
+import {joinMarkupLines} from "@romefrontend/string-markup/format";
 
 export function convertPositionToLSP(pos: undefined | Position): LSPPosition {
 	if (pos === undefined) {
@@ -61,7 +62,7 @@ export function convertDiagnosticsToLSP(
 				);
 				if (abs !== undefined) {
 					relatedInformation.push({
-						message: markupToPlainTextString(item.text),
+						message: joinMarkupLines(markupToPlainText(item.text)),
 						location: {
 							uri: `file://${abs.join()}`,
 							range: convertDiagnosticLocationToLSPRange(nextItem.location),
@@ -74,7 +75,7 @@ export function convertDiagnosticsToLSP(
 		lspDiagnostics.push({
 			severity: 1,
 			range: convertDiagnosticLocationToLSPRange(location),
-			message: markupToPlainTextString(description.message.value),
+			message: joinMarkupLines(markupToPlainText(description.message.value)),
 			code: description.category,
 			source: "rome",
 			relatedInformation,

--- a/packages/@romefrontend/string-markup/format.test.ts
+++ b/packages/@romefrontend/string-markup/format.test.ts
@@ -1,6 +1,6 @@
 import {test} from "rome";
 import {catchDiagnosticsSync} from "@romefrontend/diagnostics";
-import {markupToPlainTextString} from "./format";
+import {markupToPlainText} from "./format";
 import {printDiagnosticsToString} from "@romefrontend/cli-diagnostics";
 
 const SYNTAX_ERROR_TESTS = [
@@ -12,7 +12,7 @@ test(
 	async (t) => {
 		for (const input of SYNTAX_ERROR_TESTS) {
 			const {diagnostics} = catchDiagnosticsSync(() => {
-				markupToPlainTextString(
+				markupToPlainText(
 					input,
 					{
 						columns: 400,

--- a/packages/@romefrontend/string-markup/format.ts
+++ b/packages/@romefrontend/string-markup/format.ts
@@ -142,13 +142,6 @@ function renderGrid(
 	};
 }
 
-export function markupToPlainTextString(
-	input: string,
-	opts: UserMarkupFormatGridOptions = {},
-): string {
-	return markupToPlainText(input, opts).lines.map(({line}) => line).join("\n");
-}
-
 export function markupToPlainText(
 	input: string,
 	opts: UserMarkupFormatGridOptions = {},
@@ -168,6 +161,10 @@ export function markupToHtml(
 	opts: UserMarkupFormatGridOptions = {},
 ): MarkupLinesAndWidth {
 	return renderGrid(input, opts, "html");
+}
+
+export function joinMarkupLines({lines}: MarkupLinesAndWidth): string {
+	return lines.join("\n");
 }
 
 export function normalizeMarkup(

--- a/packages/@romefrontend/string-markup/grid/Grid.ts
+++ b/packages/@romefrontend/string-markup/grid/Grid.ts
@@ -11,7 +11,6 @@ import {
 	GridOutputFormat,
 	MarkupFormatGridOptions,
 	MarkupLineWrapMode,
-	MarkupLines,
 	MarkupPointer,
 	MarkupTagName,
 	TagNode,
@@ -27,7 +26,6 @@ import {
 	ob1Number1,
 	ob1Sub,
 } from "@romefrontend/ob1";
-import {formatAnsi} from "../ansi";
 import {
 	humanizeFileSize,
 	humanizeNumber,
@@ -234,7 +232,7 @@ export default class Grid {
 		return {...this.cursor};
 	}
 
-	getLines(format: GridOutputFormat): MarkupLines {
+	getLines(format: GridOutputFormat): Array<string> {
 		switch (format) {
 			case "ansi":
 				return this.getFormattedAnsiLines();
@@ -247,12 +245,9 @@ export default class Grid {
 		}
 	}
 
-	getUnformattedLines(): MarkupLines {
+	getUnformattedLines(): Array<string> {
 		return this.lines.map(({columns}) => {
-			return {
-				width: columns.length,
-				line: columns.join("").trimRight(),
-			};
+			return columns.join("").trimRight();
 		});
 	}
 
@@ -260,19 +255,27 @@ export default class Grid {
 		opts: {
 			normalizeText: (text: string) => string;
 			formatTag: (tag: TagNode, inner: string) => string;
-			wrapRange: (inner: string) => string;
 		},
-	): MarkupLines {
-		const lines: MarkupLines = [];
+	): Array<string> {
+		const lines: Array<string> = [];
 
 		for (const {ranges, columns} of this.lines) {
-			let content = columns.join("").trimRight();
-
 			// Sort ranges from last to first
 			const sortedRanges = ranges.sort((a, b) => b.end - a.end);
 
+			let line = "";
+
+			let lastEnd: number | undefined = undefined;
+
+			function catchUp(end: number) {
+				line = `${columns.slice(end, lastEnd).join("")}${line}`;
+				lastEnd = end;
+			}
+
 			for (const {start, end, ancestry} of sortedRanges) {
-				let substr = opts.normalizeText(content.slice(start, end));
+				catchUp(end);
+
+				let substr = opts.normalizeText(columns.slice(start, end).join(""));
 
 				// Format tags in reverse
 				for (let i = ancestry.length - 1; i >= 0; i--) {
@@ -280,35 +283,31 @@ export default class Grid {
 					substr = opts.formatTag(tag, substr);
 				}
 
-				substr = opts.wrapRange(substr);
-				content = content.slice(0, start) + substr + content.slice(end);
+				line = `${substr}${line}`;
+				lastEnd = start;
 			}
 
-			lines.push({
-				width: columns.length,
-				line: content,
-			});
+			catchUp(0);
+
+			lines.push(line.trimRight());
 		}
 
 		return lines;
 	}
 
-	getFormattedHtmlLines(): MarkupLines {
+	getFormattedHtmlLines(): Array<string> {
 		return this.getFormattedLines({
 			normalizeText: (text) => escapeXHTMLEntities(text),
 			formatTag: (tag, inner) => htmlFormatText(tag, inner),
-			wrapRange: (inner) => inner,
 		});
 	}
 
-	getFormattedAnsiLines(): MarkupLines {
+	getFormattedAnsiLines(): Array<string> {
 		return this.getFormattedLines({
 			normalizeText: (text) => text,
-			formatTag: (tag, inner) =>
-				ansiFormatText(tag, inner, this.markupOptions, this.features)
-			,
-
-			wrapRange: (inner) => formatAnsi.reset(inner),
+			formatTag: (tag, inner) => {
+				return ansiFormatText(tag, inner, this.markupOptions, this.features);
+			},
 		});
 	}
 
@@ -484,9 +483,7 @@ export default class Grid {
 			}
 			forceNextWordOverflow = false;
 
-			// NOTE: We are iterating over the word rather than using split("")
-			// This means that unicode characters that are multiple code points are displayed correctly
-			for (const char of word) {
+			for (const char of word.split(/(?:){1}/u)) {
 				this.writeChar(char);
 
 				if (source) {
@@ -730,7 +727,11 @@ export default class Grid {
 		);
 	}
 
-	drawView({children, attributes}: TagNode, ancestry: Ancestry) {
+	drawView(
+		{children, attributes}: TagNode,
+		ancestry: Ancestry,
+		shrinkViewport: number = 0,
+	) {
 		// We allow markup in the linePrefix tag... Not sure how else we can support it.
 		// NB: This assumes that the line prefix is only 1 height, maybe we could have some validation
 		const linePrefix = this.parse(
@@ -745,7 +746,12 @@ export default class Grid {
 			linePrefixStart.line !== linePrefixEnd.line ||
 			linePrefixStart.column !== linePrefixEnd.column;
 
-		const columns = this.getSubColumns(this.cursor.column);
+		// Calculate size of view
+		let columns = this.getSubColumns(this.cursor.column);
+		if (columns !== undefined) {
+			columns -= shrinkViewport;
+		}
+
 		const pointer: MarkupPointer = {
 			char: this.parse(
 				attributes.get("pointerChar").asString(""),
@@ -942,6 +948,32 @@ export default class Grid {
 
 			case "view": {
 				this.drawView(tag, subAncestry);
+				break;
+			}
+
+			case "indent": {
+				// Optimization for nested indents
+				let levels = 1;
+				let children: Children = tag.children;
+				while (
+					children.length === 1 &&
+					children[0].type === "Tag" &&
+					children[0].name === "indent"
+				) {
+					children = children[0].children;
+					levels++;
+				}
+
+				for (let i = 0; i < levels; i++) {
+					this.writeChar(" ");
+					this.writeChar(" ");
+				}
+
+				this.drawView(
+					createTag("view", createEmptyAttributes(), children),
+					ancestry,
+					levels * 2,
+				);
 				break;
 			}
 
@@ -1270,10 +1302,11 @@ hooks.set(
 	"hr",
 	{
 		after: (tag, grid, ancestry) => {
-			const size =
+			let size =
 				grid.viewportWidth === undefined
 					? 100
 					: ob1Get1(grid.viewportWidth) - ob1Get1(grid.cursor.column) + 1;
+			size = Math.max(size, 0);
 			grid.writeText("\u2501".repeat(size), ancestry, false);
 		},
 	},

--- a/packages/@romefrontend/string-markup/grid/Grid.ts
+++ b/packages/@romefrontend/string-markup/grid/Grid.ts
@@ -280,11 +280,11 @@ export default class Grid {
 	getTrimmedLines(trimColumns: boolean = true): Array<GridLine> {
 		// Remove trailing spaces
 		let lines = this.lines;
-	
+
 		if (trimColumns) {
 			lines = lines.map((line) => {
 				let {columns} = line;
-	
+
 				if (columns[columns.length - 1] === " ") {
 					columns = [...columns];
 					while (columns[columns.length - 1] === " ") {
@@ -292,19 +292,19 @@ export default class Grid {
 					}
 					return {...line, columns};
 				}
-	
+
 				return line;
 			});
 		} else {
 			lines = [...this.lines];
 		}
-	
+
 		// Remove empty columns
 		// Explicit newlines will have at least one column with an empty field
 		while (lines.length > 0 && lines[lines.length - 1].columns.length === 0) {
 			lines.pop();
 		}
-	
+
 		return lines;
 	}
 
@@ -922,7 +922,7 @@ export default class Grid {
 			tags.pointer === undefined ? undefined : this.getViewPointer(tags.pointer);
 		const linePrefixes = this.getViewLinePrefixes(tags.linePrefixes, ancestry);
 		const startCursor = this.getCursor();
-		
+
 		// Calculate size of view
 		let columns = this.getSubColumns(
 			ob1Add(startCursor.column, linePrefixes?.width || 0),

--- a/packages/@romefrontend/string-markup/index.ts
+++ b/packages/@romefrontend/string-markup/index.ts
@@ -17,12 +17,7 @@ export {
 	UserMarkupFormatGridOptions,
 } from "./types";
 
-export {
-	markupToAnsi,
-	markupToPlainText,
-	markupToPlainTextString,
-	normalizeMarkup,
-} from "./format";
+export {markupToAnsi, markupToPlainText, normalizeMarkup} from "./format";
 
 export * from "./escape";
 

--- a/packages/@romefrontend/string-markup/tags.ts
+++ b/packages/@romefrontend/string-markup/tags.ts
@@ -50,6 +50,7 @@ tags.set(
 		["singularSuffix", stringValidator],
 	]),
 );
+tags.set("indent", new Map());
 tags.set(
 	"view",
 	new Map([

--- a/packages/@romefrontend/string-markup/types.ts
+++ b/packages/@romefrontend/string-markup/types.ts
@@ -46,6 +46,7 @@ export type ChildNode = TextNode | TagNode;
 export type Children = Array<ChildNode>;
 
 export type MarkupTagName =
+	| "indent"
 	| "view"
 	| "token"
 	| "hr"
@@ -121,14 +122,9 @@ export type MarkupFormatNormalizeOptions = MarkupFormatOptions & {
 	stripPositions?: boolean;
 };
 
-export type MarkupLines = Array<{
-	line: string;
-	width: number;
-}>;
-
 export type MarkupLinesAndWidth = {
 	width: number;
-	lines: MarkupLines;
+	lines: Array<string>;
 };
 
 export type GridOutputFormat = "ansi" | "html" | "none";


### PR DESCRIPTION
This PR does the following:

 - Fixes the `rome rage` and `rome logs` commands. They were previously not functional.
 - Fixes `rome lsp --logs`. Two issues. The client reporter was being teardown and `LSPTransport` was trying to write raw JSON which can contain markup looking strings like `Array<string>`.
 - Moved indentation handling from `Reporter` into `Grid`.
 - Changed `string-markup` range application that hopefully resolves the ANSI code overflow issues
 - Renamed various methods