### PR TITLE
Update breadcrumbs styles to be consistent with website coloring

### DIFF
--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -111,13 +111,12 @@ ul.breadcrumbs {
   list-style: none;
   padding: 0;
   margin: 0;
-  background-color: #eee;
-  
+  background-color: var(--background-color);
+
   > li {
     display: inline-block;
     padding: 0;
-    line-height: 40px;
-    border-right: 1px solid red;
+    line-height: 40px;;
     position: relative;
 
     a, &.active {
@@ -142,10 +141,12 @@ ul.breadcrumbs {
     left: 0;
     list-style: none;
     margin-left: 0;
-    background-color: #aaa;
+    background-color: var(--background-color);
     padding: 0;
     max-height: 400px;
     overflow: auto;
+    border: 1px solid;
+    box-shadow: 4px 4px 10.4px -6px #999998;
 
     li {
       padding: 0;


### PR DESCRIPTION
Some screenshot to give a look and feel of the result. Feedback welcome!

<img width="352" alt="Screenshot 2020-07-14 at 11 49 02" src="https://user-images.githubusercontent.com/602478/87417469-20a47000-c5c8-11ea-9e95-543d23e57c47.png">

<img width="533" alt="Screenshot 2020-07-14 at 11 49 07" src="https://user-images.githubusercontent.com/602478/87417483-25692400-c5c8-11ea-844a-1be4c23ddd9b.png">
