### PR TITLE
More robust ANSI formatting

### DIFF
--- a/packages/@romefrontend/cli-environment/index.ts
+++ b/packages/@romefrontend/cli-environment/index.ts
@@ -1,12 +1,10 @@
 import stream = require("stream");
+import tty = require("tty");
 import {Event} from "@romefrontend/events";
 import {mergeObjects} from "@romefrontend/typescript-helpers";
 import {Number1, ob1Coerce1} from "@romefrontend/ob1";
 
-export type Stdout = stream.Writable & {
-	isTTY?: boolean;
-	columns?: number;
-};
+export type Stdout = stream.Writable | tty.WriteStream;
 
 export type InferredTerminalFeatures = {
 	features: TerminalFeatures;
@@ -17,20 +15,20 @@ export type InferredTerminalFeatures = {
 
 export type TerminalFeatures = {
 	columns?: Number1;
+	background: "dark" | "light" | "unknown";
 	cursor: boolean;
-	progressBars: boolean;
 	hyperlinks: boolean;
-	color: boolean;
+	colorDepth: 1 | 4 | 8 | 24;
 	unicode: boolean;
 };
 
 export const TERMINAL_FEATURES_DEFAULT: TerminalFeatures = {
+	background: "unknown",
 	columns: ob1Coerce1(100),
 	cursor: true,
-	progressBars: true,
 	unicode: true,
 	hyperlinks: true,
-	color: true,
+	colorDepth: 4,
 };
 
 type EnvVarStatus =
@@ -65,41 +63,52 @@ export function inferTerminalFeatures(
 	stdout?: Stdout,
 	force: Partial<TerminalFeatures> = {},
 ): InferredTerminalFeatures {
-	const isTTY = stdout?.isTTY === true;
-
-	let columns = TERMINAL_FEATURES_DEFAULT.columns;
+	let columns: Number1 = ob1Coerce1(100);
+	let colorDepth: TerminalFeatures["colorDepth"] = 1;
+	let isTTY = false;
 	let unicode = false;
-	let isCI = false;
+	let isCI = isCIEnv();
+	let background: TerminalFeatures["background"] = "unknown";
+
+	// Increase column size for CI
+	if (isCI) {
+		columns = ob1Coerce1(200);
+		colorDepth = 4;
+	}
 
 	// Only apply this environment sniffing when we've been given a process stdout stream
 	// Otherwise it'll be some custom stream and if they really want to infer from the environment
 	// Then they will do it on process.stdout and pass the features as the force param
-	if (
-		stdout !== undefined &&
-		(stdout === process.stdout || stdout === process.stderr)
-	) {
+	if (stdout instanceof tty.WriteStream) {
+		isTTY = true;
 		unicode = process.platform !== "win32";
-		isCI = isCIEnv();
-	}
-
-	if (stdout === undefined || stdout.columns === undefined) {
-		// Increase column size for CI
-		if (isCI) {
-			columns = ob1Coerce1(200);
-		}
-	} else if (stdout.columns !== undefined) {
+		colorDepth = (stdout.getColorDepth() as TerminalFeatures["colorDepth"]);
 		columns = ob1Coerce1(stdout.columns);
+
+		// Sniff for the background
+		// https://github.com/vim/vim/blob/e3f915d12c8fe0466918a29ab4eaef153f71a2cd/src/term.c#L2943-L2952
+		const COLORFGBG = getEnvVar("COLORFGBG");
+		if (COLORFGBG.type === "ENABLED") {
+			const color = parseInt(String(COLORFGBG.value).split(";").pop()!);
+			if (!isNaN(color)) {
+				if ((color >= 0 && color <= 6) || color === 8) {
+					background = "dark";
+				} else {
+					background = "light";
+				}
+			}
+		}
 	}
 
 	const fancyAnsi = isTTY && !isCI;
 
 	let features: TerminalFeatures = mergeObjects(
 		{
+			background,
 			columns,
 			cursor: fancyAnsi,
 			hyperlinks: fancyAnsi,
-			progressBars: fancyAnsi,
-			color: isTTY || isCI,
+			colorDepth,
 			unicode,
 		},
 		force,
@@ -113,9 +122,9 @@ export function inferTerminalFeatures(
 	let setupUpdateEvent: InferredTerminalFeatures["setupUpdateEvent"] = () => {};
 
 	// Watch for resizing, unless force.columns has been set and we'll consider it to be fixed
-	if (stdout !== undefined && force.columns === undefined) {
+	if (stdout instanceof tty.WriteStream && force.columns === undefined) {
 		function onStdoutResize() {
-			if (stdout?.columns !== undefined) {
+			if (stdout instanceof tty.WriteStream) {
 				features = {
 					...features,
 					columns: ob1Coerce1(stdout.columns),
@@ -142,6 +151,7 @@ export function inferTerminalFeatures(
 }
 
 const CI_ENV_NAMES = [
+	"CI",
 	"TRAVIS",
 	"CIRCLECI",
 	"APPVEYOR",

--- a/packages/@romefrontend/cli-environment/index.ts
+++ b/packages/@romefrontend/cli-environment/index.ts
@@ -22,7 +22,7 @@ export type TerminalFeatures = {
 	unicode: boolean;
 };
 
-export const TERMINAL_FEATURES_DEFAULT: TerminalFeatures = {
+export const DEFAULT_TERMINAL_FEATURES: TerminalFeatures = {
 	background: "unknown",
 	columns: ob1Coerce1(100),
 	cursor: true,

--- a/packages/@romefrontend/cli-environment/package.json
+++ b/packages/@romefrontend/cli-environment/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@romefrontend/environment",
+	"name": "@romefrontend/cli-environment",
 	"private": true,
 	"type": "module",
 	"main": "index.ts"

--- a/packages/@romefrontend/cli-layout/grid/Grid.ts
+++ b/packages/@romefrontend/cli-layout/grid/Grid.ts
@@ -44,7 +44,7 @@ import {escapeXHTMLEntities} from "@romefrontend/html-parser";
 import {ansiFormatText} from "./formatANSI";
 import {htmlFormatText} from "./formatHTML";
 import {
-	TERMINAL_FEATURES_DEFAULT,
+	DEFAULT_TERMINAL_FEATURES,
 	TerminalFeatures,
 } from "@romefrontend/cli-environment";
 import {parseMarkup} from "../parse";
@@ -117,7 +117,7 @@ export default class Grid {
 		this.options = opts;
 
 		this.features =
-			opts.features === undefined ? TERMINAL_FEATURES_DEFAULT : opts.features;
+			opts.features === undefined ? DEFAULT_TERMINAL_FEATURES : opts.features;
 
 		this.cursor = {
 			line: ob1Number1,

--- a/packages/@romefrontend/cli-layout/grid/Grid.ts
+++ b/packages/@romefrontend/cli-layout/grid/Grid.ts
@@ -46,10 +46,11 @@ import {htmlFormatText} from "./formatHTML";
 import {
 	TERMINAL_FEATURES_DEFAULT,
 	TerminalFeatures,
-} from "@romefrontend/environment";
+} from "@romefrontend/cli-environment";
 import {parseMarkup} from "../parse";
 import {Position} from "@romefrontend/parser-core";
 import {lineWrapValidator} from "../tags";
+import {formatAnsi} from "../ansi";
 
 type Cursor = {
 	line: Number1;
@@ -291,6 +292,7 @@ export default class Grid {
 		opts: {
 			normalizeText: (text: string) => string;
 			formatTag: (tag: TagNode, inner: string) => string;
+			wrapRange: (text: string) => string;
 		},
 	): Array<string> {
 		const lines: Array<string> = [];
@@ -323,6 +325,8 @@ export default class Grid {
 					substr = opts.formatTag(tag, substr);
 				}
 
+				substr = opts.wrapRange(substr);
+
 				line = `${substr}${line}`;
 				lastEnd = startIndex;
 			}
@@ -339,6 +343,7 @@ export default class Grid {
 		return this.getFormattedLines({
 			normalizeText: (text) => escapeXHTMLEntities(text),
 			formatTag: (tag, inner) => htmlFormatText(tag, inner),
+			wrapRange: (str) => str,
 		});
 	}
 
@@ -346,8 +351,9 @@ export default class Grid {
 		return this.getFormattedLines({
 			normalizeText: (text) => text,
 			formatTag: (tag, inner) => {
-				return ansiFormatText(tag, inner, this.options, this.features);
+				return ansiFormatText(tag, inner, this);
 			},
+			wrapRange: (str) => formatAnsi.reset(str),
 		});
 	}
 
@@ -1493,10 +1499,9 @@ hooks.set(
 	"hr",
 	{
 		after: (tag, grid, ancestry) => {
-			let size = 100;
-			if (grid.viewportWidth !== undefined) {
-				size = ob1Get1(grid.viewportWidth) - ob1Get1(grid.cursor.column) + 1;
-			}
+			let viewportWidth =
+				grid.viewportWidth === undefined ? 100 : ob1Get1(grid.viewportWidth);
+			let size = viewportWidth - ob1Get1(grid.cursor.column) + 1;
 			size = Math.max(size, 0);
 			grid.writeText("\u2501".repeat(size), ancestry, false);
 		},

--- a/packages/@romefrontend/cli-layout/types.ts
+++ b/packages/@romefrontend/cli-layout/types.ts
@@ -9,7 +9,7 @@ import {BaseTokens, SimpleToken, ValueToken} from "@romefrontend/parser-core";
 import {AbsoluteFilePath} from "@romefrontend/path";
 import {UserConfig} from "@romefrontend/core/common/userConfig";
 import {Number0, Number1} from "@romefrontend/ob1";
-import {TerminalFeatures} from "@romefrontend/environment";
+import {TerminalFeatures} from "@romefrontend/cli-environment";
 import {Consumer} from "@romefrontend/consume";
 
 export type Tokens = BaseTokens & {

--- a/packages/@romefrontend/cli-reporter/Progress.ts
+++ b/packages/@romefrontend/cli-reporter/Progress.ts
@@ -416,7 +416,7 @@ export default class Progress extends ProgressBase {
 		for (const stream of this.reporter.getStreams(false)) {
 			if (
 				stream.format === "ansi" &&
-				stream.features.progressBars &&
+				stream.features.cursor &&
 				stream.features.columns !== undefined
 			) {
 				stream.write(ansiEscapes.cursorTo(0));

--- a/packages/@romefrontend/cli-reporter/Reporter.ts
+++ b/packages/@romefrontend/cli-reporter/Reporter.ts
@@ -43,8 +43,8 @@ import {
 	normalizeMarkup,
 } from "@romefrontend/cli-layout/format";
 import {
-	Stdout,
 	DEFAULT_TERMINAL_FEATURES,
+	Stdout,
 	TerminalFeatures,
 	inferTerminalFeatures,
 } from "@romefrontend/cli-environment";

--- a/packages/@romefrontend/cli-reporter/Reporter.ts
+++ b/packages/@romefrontend/cli-reporter/Reporter.ts
@@ -44,7 +44,7 @@ import {
 } from "@romefrontend/cli-layout/format";
 import {
 	Stdout,
-	TERMINAL_FEATURES_DEFAULT,
+	DEFAULT_TERMINAL_FEATURES,
 	TerminalFeatures,
 	inferTerminalFeatures,
 } from "@romefrontend/cli-environment";
@@ -151,12 +151,14 @@ export default class Reporter {
 
 		const stdoutWrite: ReporterDerivedStreams["stdoutWrite"] = (chunk) => {
 			if (stdout !== undefined) {
+				// @ts-ignore
 				stdout.write(chunk);
 			}
 		};
 
 		const stderrWrite: ReporterDerivedStreams["stderrWrite"] = (chunk) => {
 			if (stderr !== undefined) {
+				// @ts-ignore
 				stderr.write(chunk);
 			}
 		};
@@ -234,7 +236,7 @@ export default class Reporter {
 		const stream: ReporterStream = {
 			format,
 			type: "all",
-			features: TERMINAL_FEATURES_DEFAULT,
+			features: DEFAULT_TERMINAL_FEATURES,
 			write(chunk) {
 				buff += chunk;
 			},

--- a/packages/@romefrontend/cli-reporter/Reporter.ts
+++ b/packages/@romefrontend/cli-reporter/Reporter.ts
@@ -47,7 +47,7 @@ import {
 	TERMINAL_FEATURES_DEFAULT,
 	TerminalFeatures,
 	inferTerminalFeatures,
-} from "@romefrontend/environment";
+} from "@romefrontend/cli-environment";
 
 type ListOptions = {
 	reverse?: boolean;
@@ -147,7 +147,7 @@ export default class Reporter {
 			force,
 		);
 
-		const {format = features.color ? "ansi" : "none"} = force;
+		const {format = features.colorDepth > 1 ? "ansi" : "none"} = force;
 
 		const stdoutWrite: ReporterDerivedStreams["stdoutWrite"] = (chunk) => {
 			if (stdout !== undefined) {

--- a/packages/@romefrontend/cli-reporter/types.ts
+++ b/packages/@romefrontend/cli-reporter/types.ts
@@ -6,7 +6,7 @@
  */
 
 import {Event} from "@romefrontend/events";
-import {TerminalFeatures} from "@romefrontend/environment";
+import {TerminalFeatures} from "@romefrontend/cli-environment";
 
 export type SelectOption = {
 	label: string;

--- a/packages/@romefrontend/cli/cli.ts
+++ b/packages/@romefrontend/cli/cli.ts
@@ -30,7 +30,7 @@ import {writeFile} from "@romefrontend/fs";
 import fs = require("fs");
 import {markup} from "@romefrontend/cli-layout";
 import {JSONObject, stringifyJSON} from "@romefrontend/codec-json";
-import {getEnvVar} from "@romefrontend/environment";
+import {getEnvVar} from "@romefrontend/cli-environment";
 import {
 	joinMarkupLines,
 	markupToPlainText,

--- a/packages/@romefrontend/core/client/Client.ts
+++ b/packages/@romefrontend/core/client/Client.ts
@@ -376,12 +376,6 @@ export default class Client {
 				);
 			}
 
-			// Add client flags
-			writer.append(
-				{name: "clientFlags.json"},
-				stringifyJSON(this.getClientJSONFlags()),
-			);
-
 			function indent(val: unknown): string {
 				const str =
 					typeof val === "string"
@@ -398,11 +392,15 @@ export default class Client {
 			}
 
 			const env = [];
+
 			env.push(`PATH: ${indent(process.env.PATH)}`);
-			env.push(`Rome version: ${indent(VERSION)}`);
-			env.push(`Node version: ${indent(process.versions.node)}`);
+			env.push(`Rome Version: ${indent(VERSION)}`);
+			env.push(`Node Version: ${indent(process.versions.node)}`);
 			env.push(`Platform: ${indent(`${process.platform} ${process.arch}`)}`);
-			writer.append({name: "environment.txt"}, `${env.join("\n\n")}\n`);
+			env.push(
+				`Terminal Features: ${indent(this.derivedReporterStreams.features)}`,
+			);
+			env.push(`Client Flags: ${indent(this.getClientJSONFlags())}`);
 
 			// Don't do this if we never connected to the server
 			const bridgeStatus = this.getBridgeStatus();
@@ -415,17 +413,11 @@ export default class Client {
 					"server",
 				);
 				if (status.type === "SUCCESS") {
-					writer.append(
-						{name: "status.txt"},
-						`${prettyFormat(
-							status.data,
-							{
-								compact: true,
-							},
-						)}\n`,
-					);
+					env.push(`Server Status: ${indent(status.data)}`);
 				}
 			}
+
+			writer.append({name: "environment.txt"}, `${env.join("\n\n")}\n`);
 
 			await writer.finalize();
 			this.reporter.success(

--- a/packages/@romefrontend/core/common/bridges/ServerBridge.ts
+++ b/packages/@romefrontend/core/common/bridges/ServerBridge.ts
@@ -16,7 +16,7 @@ import {
 	ReporterStream,
 } from "@romefrontend/cli-reporter";
 import {ServerMarker} from "../../server/Server";
-import {TerminalFeatures} from "@romefrontend/environment";
+import {TerminalFeatures} from "@romefrontend/cli-environment";
 
 export type ServerQueryRequest = {
 	requestFlags: ClientRequestFlags;

--- a/packages/@romefrontend/core/common/constants.ts
+++ b/packages/@romefrontend/core/common/constants.ts
@@ -9,7 +9,7 @@ import packageJson from "../../../../package.json";
 import os = require("os");
 
 import {TEMP_PATH, createAbsoluteFilePath} from "@romefrontend/path";
-import {getEnvVar} from "@romefrontend/environment";
+import {getEnvVar} from "@romefrontend/cli-environment";
 
 export const CHILD_ARGS = ["--max-old-space-size=8192"];
 

--- a/packages/@romefrontend/core/common/types/client.ts
+++ b/packages/@romefrontend/core/common/types/client.ts
@@ -12,7 +12,7 @@ import {
 import {Platform} from "./platform";
 import {AbsoluteFilePath, CWD_PATH} from "@romefrontend/path";
 import {ReporterStream} from "@romefrontend/cli-reporter";
-import {TerminalFeatures} from "@romefrontend/environment";
+import {TerminalFeatures} from "@romefrontend/cli-environment";
 
 export const DEFAULT_CLIENT_FLAGS: ClientFlags = {
 	clientName: "unknown",

--- a/packages/@romefrontend/core/common/userConfig.ts
+++ b/packages/@romefrontend/core/common/userConfig.ts
@@ -73,7 +73,13 @@ export function normalizeUserConfig(
 	return userConfig;
 }
 
+let loadedUserConfig: undefined | UserConfig;
+
 export function loadUserConfig(): UserConfig {
+	if (loadedUserConfig !== undefined) {
+		return loadedUserConfig;
+	}
+
 	for (const configFilename of ROME_CONFIG_FILENAMES) {
 		const configPath = HOME_PATH.append([".config", configFilename]);
 
@@ -87,8 +93,10 @@ export function loadUserConfig(): UserConfig {
 			input: configFile,
 		});
 
-		return normalizeUserConfig(consumer, configPath);
+		loadedUserConfig = normalizeUserConfig(consumer, configPath);
+		return loadedUserConfig;
 	}
 
-	return DEFAULT_USER_CONFIG;
+	loadedUserConfig = DEFAULT_USER_CONFIG;
+	return loadedUserConfig;
 }

--- a/packages/@romefrontend/core/common/utils/Logger.ts
+++ b/packages/@romefrontend/core/common/utils/Logger.ts
@@ -10,7 +10,7 @@ import {
 	ReporterConditionalStream,
 	ReporterOptions,
 } from "@romefrontend/cli-reporter";
-import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/cli-environment";
+import {DEFAULT_TERMINAL_FEATURES} from "@romefrontend/cli-environment";
 
 export default class Logger extends Reporter {
 	constructor(
@@ -29,7 +29,7 @@ export default class Logger extends Reporter {
 				type: "all",
 				format: "markup",
 				features: {
-					...TERMINAL_FEATURES_DEFAULT,
+					...DEFAULT_TERMINAL_FEATURES,
 					columns: undefined,
 				},
 				write,

--- a/packages/@romefrontend/core/common/utils/Logger.ts
+++ b/packages/@romefrontend/core/common/utils/Logger.ts
@@ -10,7 +10,7 @@ import {
 	ReporterConditionalStream,
 	ReporterOptions,
 } from "@romefrontend/cli-reporter";
-import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/environment";
+import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/cli-environment";
 
 export default class Logger extends Reporter {
 	constructor(

--- a/packages/@romefrontend/core/server/Cache.ts
+++ b/packages/@romefrontend/core/server/Cache.ts
@@ -22,7 +22,7 @@ import {
 	writeFile,
 } from "@romefrontend/fs";
 import {stringifyJSON} from "@romefrontend/codec-json";
-import {getEnvVar} from "@romefrontend/environment";
+import {getEnvVar} from "@romefrontend/cli-environment";
 
 export type CacheEntry = {
 	version: string;

--- a/packages/@romefrontend/core/server/commands/check.test.md
+++ b/packages/@romefrontend/core/server/commands/check.test.md
@@ -10,29 +10,29 @@
 
  index.js:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The unknownVariable variable is undeclared
+  ✖ The unknownVariable variable is undeclared
 
     unknownVariable
     ^^^^^^^^^^^^^^^
 
  index.js lint/pendingFixes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Pending formatting and recommended autofixes
+  ✖ Pending formatting and recommended autofixes
 
     1   │ - unknownVariable
       1 │ + unknownVariable;
       2 │ +
 
-  i To apply fixes and formatting run
+  ℹ To apply fixes and formatting run
   $ rome check index.js --apply
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-i Fixes available. To apply recommended fixes and formatting run
+ℹ Fixes available. To apply recommended fixes and formatting run
 $ rome check --apply
-i To choose fix suggestions run
+ℹ To choose fix suggestions run
 $ rome check --review
-× Found 2 problems
+✖ Found 2 problems
 
 ```
 
@@ -59,7 +59,7 @@ unknownVariable
 
  index.js:1:4 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The unformatted variable is undeclared
+  ✖ The unformatted variable is undeclared
 
   > 1 │ if (unformatted) {
       │     ^^^^^^^^^^^
@@ -68,7 +68,7 @@ unknownVariable
 
  index.js:2:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The swag variable is undeclared
+  ✖ The swag variable is undeclared
 
     1 │ if (unformatted) {
   > 2 │   swag;
@@ -77,8 +77,8 @@ unknownVariable
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-√ 1 file updated
-× Found 2 problems
+✔ 1 file updated
+✖ Found 2 problems
 
 ```
 

--- a/packages/@romefrontend/core/server/web/index.ts
+++ b/packages/@romefrontend/core/server/web/index.ts
@@ -25,7 +25,7 @@ import {AbsoluteFilePath} from "@romefrontend/path";
 import {PLATFORMS} from "../../common/types/platform";
 import {HmrClientLogMessage, HmrServerMessage} from "./hmr";
 import {ConsumableUrl} from "@romefrontend/codec-url";
-import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/cli-environment";
+import {DEFAULT_TERMINAL_FEATURES} from "@romefrontend/cli-environment";
 
 export type WebServerTime = {
 	startTime: number;
@@ -91,7 +91,7 @@ export class WebServer {
 			const ansiReporterStream: ReporterStream = {
 				type: "all",
 				format: "ansi",
-				features: TERMINAL_FEATURES_DEFAULT,
+				features: DEFAULT_TERMINAL_FEATURES,
 				write(chunk) {
 					data.stdoutAnsi += chunk;
 				},
@@ -100,7 +100,7 @@ export class WebServer {
 			const htmlReporterStream: ReporterStream = {
 				type: "all",
 				format: "html",
-				features: TERMINAL_FEATURES_DEFAULT,
+				features: DEFAULT_TERMINAL_FEATURES,
 				write(chunk) {
 					data.stdoutHTML += chunk;
 				},

--- a/packages/@romefrontend/core/server/web/index.ts
+++ b/packages/@romefrontend/core/server/web/index.ts
@@ -25,7 +25,7 @@ import {AbsoluteFilePath} from "@romefrontend/path";
 import {PLATFORMS} from "../../common/types/platform";
 import {HmrClientLogMessage, HmrServerMessage} from "./hmr";
 import {ConsumableUrl} from "@romefrontend/codec-url";
-import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/environment";
+import {TERMINAL_FEATURES_DEFAULT} from "@romefrontend/cli-environment";
 
 export type WebServerTime = {
 	startTime: number;

--- a/packages/@romefrontend/path/index.ts
+++ b/packages/@romefrontend/path/index.ts
@@ -69,7 +69,12 @@ class BaseFilePath<Super extends UnknownFilePath> {
 	}
 
 	toMarkup(): string {
-		return `<filelink target="${escapeMarkup(this.join())}" />`;
+		let target = escapeMarkup(this.join());
+		// Remove trailing slash if present as an explicit folder
+		if (target[target.length - 1] === "/") {
+			target = target.slice(0, -1);
+		}
+		return `<filelink target="${target}" />`;
 	}
 
 	getParsed(): ParsedPath {

--- a/packages/@romefrontend/test-helpers/integration.ts
+++ b/packages/@romefrontend/test-helpers/integration.ts
@@ -26,7 +26,7 @@ import {
 	removeDirectory,
 	writeFile,
 } from "@romefrontend/fs";
-import {Stdout} from "@romefrontend/environment";
+import {Stdout} from "@romefrontend/cli-environment";
 import {Dict} from "@romefrontend/typescript-helpers";
 import {DEFAULT_USER_CONFIG, UserConfig} from "../core/common/userConfig";
 import ServerRequest from "../core/server/ServerRequest";

--- a/packages/@romefrontend/test-helpers/integration.ts
+++ b/packages/@romefrontend/test-helpers/integration.ts
@@ -26,7 +26,7 @@ import {
 	removeDirectory,
 	writeFile,
 } from "@romefrontend/fs";
-import {Stdout} from "@romefrontend/cli-environment";
+import {Stdout, DEFAULT_TERMINAL_FEATURES} from "@romefrontend/cli-environment";
 import {Dict} from "@romefrontend/typescript-helpers";
 import {DEFAULT_USER_CONFIG, UserConfig} from "../core/common/userConfig";
 import ServerRequest from "../core/server/ServerRequest";
@@ -54,6 +54,8 @@ import crypto = require("crypto");
 import stream = require("stream");
 import {ExtensionHandler} from "../core/common/file-handlers/types";
 import {DiagnosticsProcessor} from "@romefrontend/diagnostics";
+import { markupToPlainText } from "@romefrontend/cli-layout";
+import { joinMarkupLines } from "@romefrontend/cli-layout/format";
 
 type IntegrationTestHelper = {
 	cwd: AbsoluteFilePath;
@@ -345,7 +347,7 @@ export function createIntegrationTest(
 
 			// Create a Client. The abstraction used by the CLI.
 			const client = new Client({
-				terminalFeatures: {},
+				terminalFeatures: DEFAULT_TERMINAL_FEATURES,
 				globalErrorHandlers: false,
 				flags: {
 					cwd: projectPath,
@@ -362,7 +364,7 @@ export function createIntegrationTest(
 				await client.subscribeLogs(
 					true,
 					(chunk) => {
-						logs += chunk;
+						logs += joinMarkupLines(markupToPlainText(chunk));
 					},
 				);
 			});

--- a/packages/@romefrontend/test-helpers/integration.ts
+++ b/packages/@romefrontend/test-helpers/integration.ts
@@ -347,7 +347,10 @@ export function createIntegrationTest(
 
 			// Create a Client. The abstraction used by the CLI.
 			const client = new Client({
-				terminalFeatures: DEFAULT_TERMINAL_FEATURES,
+				terminalFeatures: {
+					...DEFAULT_TERMINAL_FEATURES,
+					format: "none",
+				},
 				globalErrorHandlers: false,
 				flags: {
 					cwd: projectPath,

--- a/packages/@romefrontend/test-helpers/integration.ts
+++ b/packages/@romefrontend/test-helpers/integration.ts
@@ -26,7 +26,7 @@ import {
 	removeDirectory,
 	writeFile,
 } from "@romefrontend/fs";
-import {Stdout, DEFAULT_TERMINAL_FEATURES} from "@romefrontend/cli-environment";
+import {DEFAULT_TERMINAL_FEATURES, Stdout} from "@romefrontend/cli-environment";
 import {Dict} from "@romefrontend/typescript-helpers";
 import {DEFAULT_USER_CONFIG, UserConfig} from "../core/common/userConfig";
 import ServerRequest from "../core/server/ServerRequest";
@@ -54,8 +54,8 @@ import crypto = require("crypto");
 import stream = require("stream");
 import {ExtensionHandler} from "../core/common/file-handlers/types";
 import {DiagnosticsProcessor} from "@romefrontend/diagnostics";
-import { markupToPlainText } from "@romefrontend/cli-layout";
-import { joinMarkupLines } from "@romefrontend/cli-layout/format";
+import {markupToPlainText} from "@romefrontend/cli-layout";
+import {joinMarkupLines} from "@romefrontend/cli-layout/format";
 
 type IntegrationTestHelper = {
 	cwd: AbsoluteFilePath;


### PR DESCRIPTION
This PR does the following:

 - Renames the `color` property of `TerminalFeatures` to `colorDepth`.
 - Uses `tty.WriteStream` `getColorDepth` to infer supported terminal colors.
 - Adds `background` property to `TerminalFeatures` that is sniffed from `env.COLORFGBG`. It can be set to `"dark"`, `"light"`, or `"unknown"`.
 - Disables default syntax highlighting theme if we aren't 100% sure the user has a dark background. If a user has set their own syntax theme then it will be enabled again.
 - Adds color conversion for `rgb` values in a 4/16 bit terminal.
 - Inserts reset color codes within grid formatting ranges.
 - Adds terminal features to `rome rage` - closes #811.

These changes result in a much better cross-terminal experience by gracefully handling coloring. The heuristics used are reliable.