### PR TITLE
Switch to dotted list for showing list of rules inside website

### DIFF
--- a/scripts/generated-files/lint-rules.cjs
+++ b/scripts/generated-files/lint-rules.cjs
@@ -110,7 +110,7 @@ const categoryAlias = {
 	ts: "TypeScript",
 };
 
-let docTemplateTable = null;
+let docTemplateTable = "";
 
 for (const {basename, ruleName, category, docs} of defs) {
 	if (categoryAlias[category]) {
@@ -120,8 +120,6 @@ for (const {basename, ruleName, category, docs} of defs) {
 		}
 
 		docTemplate += `## ${categoryAlias[category]}\n\n`;
-
-		docTemplateTable = "| Rule | Description |\n| ------------- | ------------- |\n";
 	}
 
 	// Remove this, so each doc headings will be added once
@@ -133,8 +131,8 @@ for (const {basename, ruleName, category, docs} of defs) {
 		console.log(`/docs/lint/rules/${ruleName}.md is missing a description\n`);
 	}
 
-	docTemplateTable += `| [${basename}](/docs/lint/rules/${ruleName}) | ${description ||
-	""} |\n`;
+	docTemplateTable += `- [${basename}](/docs/lint/rules/${ruleName}):  ${description ||
+	""}\n`;
 }
 
 docTemplate += docTemplateTable;

--- a/website/src/docs/lint/rules/index.md
+++ b/website/src/docs/lint/rules/index.md
@@ -15,128 +15,358 @@ eleventyNavigation: {
 
 ## JavaScript
 
-| Rule | Description |
-| ------------- | ------------- |
-| [camelCase](/docs/lint/rules/js/camelCase) |  MISSING DOCUMENTATION |
-| [caseSingleStatement](/docs/lint/rules/js/caseSingleStatement) |  MISSING DOCUMENTATION |
-| [confusingLanguage](/docs/lint/rules/js/confusingLanguage) |  MISSING DOCUMENTATION |
-| [defaultExportSameBasename](/docs/lint/rules/js/defaultExportSameBasename) |  MISSING DOCUMENTATION |
-| [doubleEquals](/docs/lint/rules/js/doubleEquals) |  MISSING DOCUMENTATION |
-| [duplicateImportSource](/docs/lint/rules/js/duplicateImportSource) |  MISSING DOCUMENTATION |
-| [emptyBlocks](/docs/lint/rules/js/emptyBlocks) |  MISSING DOCUMENTATION |
-| [emptyMatches](/docs/lint/rules/js/emptyMatches) |  MISSING DOCUMENTATION |
-| [getterReturn](/docs/lint/rules/js/getterReturn) |  MISSING DOCUMENTATION |
-| [importDefaultBasename](/docs/lint/rules/js/importDefaultBasename) |  MISSING DOCUMENTATION |
-| [negationElse](/docs/lint/rules/js/negationElse) |  MISSING DOCUMENTATION |
-| [noArguments](/docs/lint/rules/js/noArguments) |  MISSING DOCUMENTATION |
-| [noAsyncPromiseExecutor](/docs/lint/rules/js/noAsyncPromiseExecutor) |  MISSING DOCUMENTATION |
-| [noCatchAssign](/docs/lint/rules/js/noCatchAssign) |  MISSING DOCUMENTATION |
-| [noCommaOperator](/docs/lint/rules/js/noCommaOperator) |  MISSING DOCUMENTATION |
-| [noCompareNegZero](/docs/lint/rules/js/noCompareNegZero) |  MISSING DOCUMENTATION |
-| [noCondAssign](/docs/lint/rules/js/noCondAssign) |  MISSING DOCUMENTATION |
-| [noDebugger](/docs/lint/rules/js/noDebugger) |  MISSING DOCUMENTATION |
-| [noDelete](/docs/lint/rules/js/noDelete) |  MISSING DOCUMENTATION |
-| [noDeleteVars](/docs/lint/rules/js/noDeleteVars) |  MISSING DOCUMENTATION |
-| [noDupeArgs](/docs/lint/rules/js/noDupeArgs) |  MISSING DOCUMENTATION |
-| [noDuplicateCase](/docs/lint/rules/js/noDuplicateCase) |  MISSING DOCUMENTATION |
-| [noDuplicateGroupNamesInRegularExpressions](/docs/lint/rules/js/noDuplicateGroupNamesInRegularExpressions) |  MISSING DOCUMENTATION |
-| [noDuplicateKeys](/docs/lint/rules/js/noDuplicateKeys) |  MISSING DOCUMENTATION |
-| [noEmptyCharacterClass](/docs/lint/rules/js/noEmptyCharacterClass) |  MISSING DOCUMENTATION |
-| [noExtraBooleanCast](/docs/lint/rules/js/noExtraBooleanCast) |  MISSING DOCUMENTATION |
-| [noFunctionAssign](/docs/lint/rules/js/noFunctionAssign) |  MISSING DOCUMENTATION |
-| [noImportAssign](/docs/lint/rules/js/noImportAssign) |  MISSING DOCUMENTATION |
-| [noLabelVar](/docs/lint/rules/js/noLabelVar) |  MISSING DOCUMENTATION |
-| [noMultipleSpacesInRegularExpressionLiterals](/docs/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals) |  MISSING DOCUMENTATION |
-| [noNestedTernary](/docs/lint/rules/js/noNestedTernary) |  MISSING DOCUMENTATION |
-| [noPosixInRegularExpression](/docs/lint/rules/js/noPosixInRegularExpression) |  MISSING DOCUMENTATION |
-| [noReferenceToNonExistingGroup](/docs/lint/rules/js/noReferenceToNonExistingGroup) |  MISSING DOCUMENTATION |
-| [noSetterReturn](/docs/lint/rules/js/noSetterReturn) |  MISSING DOCUMENTATION |
-| [noShadowRestrictedNames](/docs/lint/rules/js/noShadowRestrictedNames) |  MISSING DOCUMENTATION |
-| [noShorthandArrayType](/docs/lint/rules/js/noShorthandArrayType) |  MISSING DOCUMENTATION |
-| [noTemplateCurlyInString](/docs/lint/rules/js/noTemplateCurlyInString) |  MISSING DOCUMENTATION |
-| [noUnsafeFinally](/docs/lint/rules/js/noUnsafeFinally) |  MISSING DOCUMENTATION |
-| [noUnusedTemplateLiteral](/docs/lint/rules/js/noUnusedTemplateLiteral) |  MISSING DOCUMENTATION |
-| [noUnusedVariables](/docs/lint/rules/js/noUnusedVariables) |  MISSING DOCUMENTATION |
-| [noVar](/docs/lint/rules/js/noVar) |  MISSING DOCUMENTATION |
-| [preferBlockStatements](/docs/lint/rules/js/preferBlockStatements) |  MISSING DOCUMENTATION |
-| [preferFunctionDeclarations](/docs/lint/rules/js/preferFunctionDeclarations) |  MISSING DOCUMENTATION |
-| [preferTemplate](/docs/lint/rules/js/preferTemplate) |  MISSING DOCUMENTATION |
-| [preferWhile](/docs/lint/rules/js/preferWhile) |  MISSING DOCUMENTATION |
-| [restrictedGlobals](/docs/lint/rules/js/restrictedGlobals) |  MISSING DOCUMENTATION |
-| [singleVarDeclarator](/docs/lint/rules/js/singleVarDeclarator) |  MISSING DOCUMENTATION |
-| [sortImportExportSpecifiers](/docs/lint/rules/js/sortImportExportSpecifiers) |  MISSING DOCUMENTATION |
-| [sparseArray](/docs/lint/rules/js/sparseArray) |  MISSING DOCUMENTATION |
-| [undeclaredVariables](/docs/lint/rules/js/undeclaredVariables) |  MISSING DOCUMENTATION |
-| [unsafeNegation](/docs/lint/rules/js/unsafeNegation) |  MISSING DOCUMENTATION |
+- [camelCase](/docs/lint/rules/js/camelCase):   MISSING DOCUMENTATION
+- [caseSingleStatement](/docs/lint/rules/js/caseSingleStatement):   MISSING DOCUMENTATION
+- [confusingLanguage](/docs/lint/rules/js/confusingLanguage):   MISSING DOCUMENTATION
+- [defaultExportSameBasename](/docs/lint/rules/js/defaultExportSameBasename):   MISSING DOCUMENTATION
+- [doubleEquals](/docs/lint/rules/js/doubleEquals):   MISSING DOCUMENTATION
+- [duplicateImportSource](/docs/lint/rules/js/duplicateImportSource):   MISSING DOCUMENTATION
+- [emptyBlocks](/docs/lint/rules/js/emptyBlocks):   MISSING DOCUMENTATION
+- [emptyMatches](/docs/lint/rules/js/emptyMatches):   MISSING DOCUMENTATION
+- [getterReturn](/docs/lint/rules/js/getterReturn):   MISSING DOCUMENTATION
+- [importDefaultBasename](/docs/lint/rules/js/importDefaultBasename):   MISSING DOCUMENTATION
+- [negationElse](/docs/lint/rules/js/negationElse):   MISSING DOCUMENTATION
+- [noArguments](/docs/lint/rules/js/noArguments):   MISSING DOCUMENTATION
+- [noAsyncPromiseExecutor](/docs/lint/rules/js/noAsyncPromiseExecutor):   MISSING DOCUMENTATION
+- [noCatchAssign](/docs/lint/rules/js/noCatchAssign):   MISSING DOCUMENTATION
+- [noCommaOperator](/docs/lint/rules/js/noCommaOperator):   MISSING DOCUMENTATION
+- [noCompareNegZero](/docs/lint/rules/js/noCompareNegZero):   MISSING DOCUMENTATION
+- [noCondAssign](/docs/lint/rules/js/noCondAssign):   MISSING DOCUMENTATION
+- [noDebugger](/docs/lint/rules/js/noDebugger):   MISSING DOCUMENTATION
+- [noDelete](/docs/lint/rules/js/noDelete):   MISSING DOCUMENTATION
+- [noDeleteVars](/docs/lint/rules/js/noDeleteVars):   MISSING DOCUMENTATION
+- [noDupeArgs](/docs/lint/rules/js/noDupeArgs):   MISSING DOCUMENTATION
+- [noDuplicateCase](/docs/lint/rules/js/noDuplicateCase):   MISSING DOCUMENTATION
+- [noDuplicateGroupNamesInRegularExpressions](/docs/lint/rules/js/noDuplicateGroupNamesInRegularExpressions):   MISSING DOCUMENTATION
+- [noDuplicateKeys](/docs/lint/rules/js/noDuplicateKeys):   MISSING DOCUMENTATION
+- [noEmptyCharacterClass](/docs/lint/rules/js/noEmptyCharacterClass):   MISSING DOCUMENTATION
+- [noExtraBooleanCast](/docs/lint/rules/js/noExtraBooleanCast):   MISSING DOCUMENTATION
+- [noFunctionAssign](/docs/lint/rules/js/noFunctionAssign):   MISSING DOCUMENTATION
+- [noImportAssign](/docs/lint/rules/js/noImportAssign):   MISSING DOCUMENTATION
+- [noLabelVar](/docs/lint/rules/js/noLabelVar):   MISSING DOCUMENTATION
+- [noMultipleSpacesInRegularExpressionLiterals](/docs/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals):   MISSING DOCUMENTATION
+- [noNestedTernary](/docs/lint/rules/js/noNestedTernary):   MISSING DOCUMENTATION
+- [noPosixInRegularExpression](/docs/lint/rules/js/noPosixInRegularExpression):   MISSING DOCUMENTATION
+- [noReferenceToNonExistingGroup](/docs/lint/rules/js/noReferenceToNonExistingGroup):   MISSING DOCUMENTATION
+- [noSetterReturn](/docs/lint/rules/js/noSetterReturn):   MISSING DOCUMENTATION
+- [noShadowRestrictedNames](/docs/lint/rules/js/noShadowRestrictedNames):   MISSING DOCUMENTATION
+- [noShorthandArrayType](/docs/lint/rules/js/noShorthandArrayType):   MISSING DOCUMENTATION
+- [noTemplateCurlyInString](/docs/lint/rules/js/noTemplateCurlyInString):   MISSING DOCUMENTATION
+- [noUnsafeFinally](/docs/lint/rules/js/noUnsafeFinally):   MISSING DOCUMENTATION
+- [noUnusedTemplateLiteral](/docs/lint/rules/js/noUnusedTemplateLiteral):   MISSING DOCUMENTATION
+- [noUnusedVariables](/docs/lint/rules/js/noUnusedVariables):   MISSING DOCUMENTATION
+- [noVar](/docs/lint/rules/js/noVar):   MISSING DOCUMENTATION
+- [preferBlockStatements](/docs/lint/rules/js/preferBlockStatements):   MISSING DOCUMENTATION
+- [preferFunctionDeclarations](/docs/lint/rules/js/preferFunctionDeclarations):   MISSING DOCUMENTATION
+- [preferTemplate](/docs/lint/rules/js/preferTemplate):   MISSING DOCUMENTATION
+- [preferWhile](/docs/lint/rules/js/preferWhile):   MISSING DOCUMENTATION
+- [restrictedGlobals](/docs/lint/rules/js/restrictedGlobals):   MISSING DOCUMENTATION
+- [singleVarDeclarator](/docs/lint/rules/js/singleVarDeclarator):   MISSING DOCUMENTATION
+- [sortImportExportSpecifiers](/docs/lint/rules/js/sortImportExportSpecifiers):   MISSING DOCUMENTATION
+- [sparseArray](/docs/lint/rules/js/sparseArray):   MISSING DOCUMENTATION
+- [undeclaredVariables](/docs/lint/rules/js/undeclaredVariables):   MISSING DOCUMENTATION
+- [unsafeNegation](/docs/lint/rules/js/unsafeNegation):   MISSING DOCUMENTATION
 
 ## JSX Accessibility
 
-| Rule | Description |
-| ------------- | ------------- |
-| [altText](/docs/lint/rules/jsx-a11y/altText) |  MISSING DOCUMENTATION |
-| [anchorHasContent](/docs/lint/rules/jsx-a11y/anchorHasContent) |  MISSING DOCUMENTATION |
-| [anchorIsValid](/docs/lint/rules/jsx-a11y/anchorIsValid) |  MISSING DOCUMENTATION |
-| [ariaProps](/docs/lint/rules/jsx-a11y/ariaProps) |  MISSING DOCUMENTATION |
-| [ariaProptypes](/docs/lint/rules/jsx-a11y/ariaProptypes) |  MISSING DOCUMENTATION |
-| [ariaUnsupportedElements](/docs/lint/rules/jsx-a11y/ariaUnsupportedElements) |  MISSING DOCUMENTATION |
-| [clickEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/clickEventsHaveKeyEvents) |  MISSING DOCUMENTATION |
-| [headingHasContent](/docs/lint/rules/jsx-a11y/headingHasContent) |  MISSING DOCUMENTATION |
-| [htmlHasLang](/docs/lint/rules/jsx-a11y/htmlHasLang) |  MISSING DOCUMENTATION |
-| [iframeHasTitle](/docs/lint/rules/jsx-a11y/iframeHasTitle) |  MISSING DOCUMENTATION |
-| [imgRedundantAlt](/docs/lint/rules/jsx-a11y/imgRedundantAlt) |  MISSING DOCUMENTATION |
-| [lang](/docs/lint/rules/jsx-a11y/lang) |  MISSING DOCUMENTATION |
-| [mediaHasCaption](/docs/lint/rules/jsx-a11y/mediaHasCaption) |  MISSING DOCUMENTATION |
-| [mouseEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/mouseEventsHaveKeyEvents) |  MISSING DOCUMENTATION |
-| [noAccessKey](/docs/lint/rules/jsx-a11y/noAccessKey) |  MISSING DOCUMENTATION |
-| [noAutofocus](/docs/lint/rules/jsx-a11y/noAutofocus) |  MISSING DOCUMENTATION |
-| [noDistractingElements](/docs/lint/rules/jsx-a11y/noDistractingElements) |  MISSING DOCUMENTATION |
-| [noNoninteractiveElementToInteractiveRole](/docs/lint/rules/jsx-a11y/noNoninteractiveElementToInteractiveRole) |  MISSING DOCUMENTATION |
-| [noNoninteractiveTabindex](/docs/lint/rules/jsx-a11y/noNoninteractiveTabindex) |  MISSING DOCUMENTATION |
-| [noOnChange](/docs/lint/rules/jsx-a11y/noOnChange) |  MISSING DOCUMENTATION |
-| [noRedundantRoles](/docs/lint/rules/jsx-a11y/noRedundantRoles) |  MISSING DOCUMENTATION |
-| [noTargetBlank](/docs/lint/rules/jsx-a11y/noTargetBlank) |  MISSING DOCUMENTATION |
-| [roleHasRequiredAriaProps](/docs/lint/rules/jsx-a11y/roleHasRequiredAriaProps) |  MISSING DOCUMENTATION |
-| [scope](/docs/lint/rules/jsx-a11y/scope) |  MISSING DOCUMENTATION |
-| [tabindexNoPositive](/docs/lint/rules/jsx-a11y/tabindexNoPositive) |  MISSING DOCUMENTATION |
-| [fileExtension](/docs/lint/rules/jsx/fileExtension) |  MISSING DOCUMENTATION |
-| [noCommentText](/docs/lint/rules/jsx/noCommentText) |  MISSING DOCUMENTATION |
-| [noDuplicateProps](/docs/lint/rules/jsx/noDuplicateProps) |  MISSING DOCUMENTATION |
-| [noImplicitBoolean](/docs/lint/rules/jsx/noImplicitBoolean) |  MISSING DOCUMENTATION |
-| [pascalCase](/docs/lint/rules/jsx/pascalCase) |  MISSING DOCUMENTATION |
-| [propsNoSpreading](/docs/lint/rules/jsx/propsNoSpreading) |  MISSING DOCUMENTATION |
+- [camelCase](/docs/lint/rules/js/camelCase):   MISSING DOCUMENTATION
+- [caseSingleStatement](/docs/lint/rules/js/caseSingleStatement):   MISSING DOCUMENTATION
+- [confusingLanguage](/docs/lint/rules/js/confusingLanguage):   MISSING DOCUMENTATION
+- [defaultExportSameBasename](/docs/lint/rules/js/defaultExportSameBasename):   MISSING DOCUMENTATION
+- [doubleEquals](/docs/lint/rules/js/doubleEquals):   MISSING DOCUMENTATION
+- [duplicateImportSource](/docs/lint/rules/js/duplicateImportSource):   MISSING DOCUMENTATION
+- [emptyBlocks](/docs/lint/rules/js/emptyBlocks):   MISSING DOCUMENTATION
+- [emptyMatches](/docs/lint/rules/js/emptyMatches):   MISSING DOCUMENTATION
+- [getterReturn](/docs/lint/rules/js/getterReturn):   MISSING DOCUMENTATION
+- [importDefaultBasename](/docs/lint/rules/js/importDefaultBasename):   MISSING DOCUMENTATION
+- [negationElse](/docs/lint/rules/js/negationElse):   MISSING DOCUMENTATION
+- [noArguments](/docs/lint/rules/js/noArguments):   MISSING DOCUMENTATION
+- [noAsyncPromiseExecutor](/docs/lint/rules/js/noAsyncPromiseExecutor):   MISSING DOCUMENTATION
+- [noCatchAssign](/docs/lint/rules/js/noCatchAssign):   MISSING DOCUMENTATION
+- [noCommaOperator](/docs/lint/rules/js/noCommaOperator):   MISSING DOCUMENTATION
+- [noCompareNegZero](/docs/lint/rules/js/noCompareNegZero):   MISSING DOCUMENTATION
+- [noCondAssign](/docs/lint/rules/js/noCondAssign):   MISSING DOCUMENTATION
+- [noDebugger](/docs/lint/rules/js/noDebugger):   MISSING DOCUMENTATION
+- [noDelete](/docs/lint/rules/js/noDelete):   MISSING DOCUMENTATION
+- [noDeleteVars](/docs/lint/rules/js/noDeleteVars):   MISSING DOCUMENTATION
+- [noDupeArgs](/docs/lint/rules/js/noDupeArgs):   MISSING DOCUMENTATION
+- [noDuplicateCase](/docs/lint/rules/js/noDuplicateCase):   MISSING DOCUMENTATION
+- [noDuplicateGroupNamesInRegularExpressions](/docs/lint/rules/js/noDuplicateGroupNamesInRegularExpressions):   MISSING DOCUMENTATION
+- [noDuplicateKeys](/docs/lint/rules/js/noDuplicateKeys):   MISSING DOCUMENTATION
+- [noEmptyCharacterClass](/docs/lint/rules/js/noEmptyCharacterClass):   MISSING DOCUMENTATION
+- [noExtraBooleanCast](/docs/lint/rules/js/noExtraBooleanCast):   MISSING DOCUMENTATION
+- [noFunctionAssign](/docs/lint/rules/js/noFunctionAssign):   MISSING DOCUMENTATION
+- [noImportAssign](/docs/lint/rules/js/noImportAssign):   MISSING DOCUMENTATION
+- [noLabelVar](/docs/lint/rules/js/noLabelVar):   MISSING DOCUMENTATION
+- [noMultipleSpacesInRegularExpressionLiterals](/docs/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals):   MISSING DOCUMENTATION
+- [noNestedTernary](/docs/lint/rules/js/noNestedTernary):   MISSING DOCUMENTATION
+- [noPosixInRegularExpression](/docs/lint/rules/js/noPosixInRegularExpression):   MISSING DOCUMENTATION
+- [noReferenceToNonExistingGroup](/docs/lint/rules/js/noReferenceToNonExistingGroup):   MISSING DOCUMENTATION
+- [noSetterReturn](/docs/lint/rules/js/noSetterReturn):   MISSING DOCUMENTATION
+- [noShadowRestrictedNames](/docs/lint/rules/js/noShadowRestrictedNames):   MISSING DOCUMENTATION
+- [noShorthandArrayType](/docs/lint/rules/js/noShorthandArrayType):   MISSING DOCUMENTATION
+- [noTemplateCurlyInString](/docs/lint/rules/js/noTemplateCurlyInString):   MISSING DOCUMENTATION
+- [noUnsafeFinally](/docs/lint/rules/js/noUnsafeFinally):   MISSING DOCUMENTATION
+- [noUnusedTemplateLiteral](/docs/lint/rules/js/noUnusedTemplateLiteral):   MISSING DOCUMENTATION
+- [noUnusedVariables](/docs/lint/rules/js/noUnusedVariables):   MISSING DOCUMENTATION
+- [noVar](/docs/lint/rules/js/noVar):   MISSING DOCUMENTATION
+- [preferBlockStatements](/docs/lint/rules/js/preferBlockStatements):   MISSING DOCUMENTATION
+- [preferFunctionDeclarations](/docs/lint/rules/js/preferFunctionDeclarations):   MISSING DOCUMENTATION
+- [preferTemplate](/docs/lint/rules/js/preferTemplate):   MISSING DOCUMENTATION
+- [preferWhile](/docs/lint/rules/js/preferWhile):   MISSING DOCUMENTATION
+- [restrictedGlobals](/docs/lint/rules/js/restrictedGlobals):   MISSING DOCUMENTATION
+- [singleVarDeclarator](/docs/lint/rules/js/singleVarDeclarator):   MISSING DOCUMENTATION
+- [sortImportExportSpecifiers](/docs/lint/rules/js/sortImportExportSpecifiers):   MISSING DOCUMENTATION
+- [sparseArray](/docs/lint/rules/js/sparseArray):   MISSING DOCUMENTATION
+- [undeclaredVariables](/docs/lint/rules/js/undeclaredVariables):   MISSING DOCUMENTATION
+- [unsafeNegation](/docs/lint/rules/js/unsafeNegation):   MISSING DOCUMENTATION
+- [altText](/docs/lint/rules/jsx-a11y/altText):   MISSING DOCUMENTATION
+- [anchorHasContent](/docs/lint/rules/jsx-a11y/anchorHasContent):   MISSING DOCUMENTATION
+- [anchorIsValid](/docs/lint/rules/jsx-a11y/anchorIsValid):   MISSING DOCUMENTATION
+- [ariaProps](/docs/lint/rules/jsx-a11y/ariaProps):   MISSING DOCUMENTATION
+- [ariaProptypes](/docs/lint/rules/jsx-a11y/ariaProptypes):   MISSING DOCUMENTATION
+- [ariaUnsupportedElements](/docs/lint/rules/jsx-a11y/ariaUnsupportedElements):   MISSING DOCUMENTATION
+- [clickEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/clickEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [headingHasContent](/docs/lint/rules/jsx-a11y/headingHasContent):   MISSING DOCUMENTATION
+- [htmlHasLang](/docs/lint/rules/jsx-a11y/htmlHasLang):   MISSING DOCUMENTATION
+- [iframeHasTitle](/docs/lint/rules/jsx-a11y/iframeHasTitle):   MISSING DOCUMENTATION
+- [imgRedundantAlt](/docs/lint/rules/jsx-a11y/imgRedundantAlt):   MISSING DOCUMENTATION
+- [lang](/docs/lint/rules/jsx-a11y/lang):   MISSING DOCUMENTATION
+- [mediaHasCaption](/docs/lint/rules/jsx-a11y/mediaHasCaption):   MISSING DOCUMENTATION
+- [mouseEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/mouseEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [noAccessKey](/docs/lint/rules/jsx-a11y/noAccessKey):   MISSING DOCUMENTATION
+- [noAutofocus](/docs/lint/rules/jsx-a11y/noAutofocus):   MISSING DOCUMENTATION
+- [noDistractingElements](/docs/lint/rules/jsx-a11y/noDistractingElements):   MISSING DOCUMENTATION
+- [noNoninteractiveElementToInteractiveRole](/docs/lint/rules/jsx-a11y/noNoninteractiveElementToInteractiveRole):   MISSING DOCUMENTATION
+- [noNoninteractiveTabindex](/docs/lint/rules/jsx-a11y/noNoninteractiveTabindex):   MISSING DOCUMENTATION
+- [noOnChange](/docs/lint/rules/jsx-a11y/noOnChange):   MISSING DOCUMENTATION
+- [noRedundantRoles](/docs/lint/rules/jsx-a11y/noRedundantRoles):   MISSING DOCUMENTATION
+- [noTargetBlank](/docs/lint/rules/jsx-a11y/noTargetBlank):   MISSING DOCUMENTATION
+- [roleHasRequiredAriaProps](/docs/lint/rules/jsx-a11y/roleHasRequiredAriaProps):   MISSING DOCUMENTATION
+- [scope](/docs/lint/rules/jsx-a11y/scope):   MISSING DOCUMENTATION
+- [tabindexNoPositive](/docs/lint/rules/jsx-a11y/tabindexNoPositive):   MISSING DOCUMENTATION
+- [fileExtension](/docs/lint/rules/jsx/fileExtension):   MISSING DOCUMENTATION
+- [noCommentText](/docs/lint/rules/jsx/noCommentText):   MISSING DOCUMENTATION
+- [noDuplicateProps](/docs/lint/rules/jsx/noDuplicateProps):   MISSING DOCUMENTATION
+- [noImplicitBoolean](/docs/lint/rules/jsx/noImplicitBoolean):   MISSING DOCUMENTATION
+- [pascalCase](/docs/lint/rules/jsx/pascalCase):   MISSING DOCUMENTATION
+- [propsNoSpreading](/docs/lint/rules/jsx/propsNoSpreading):   MISSING DOCUMENTATION
 
 ## React
 
-| Rule | Description |
-| ------------- | ------------- |
-| [buttonHasType](/docs/lint/rules/react/buttonHasType) |  MISSING DOCUMENTATION |
-| [jsxFragments](/docs/lint/rules/react/jsxFragments) |  MISSING DOCUMENTATION |
-| [jsxKey](/docs/lint/rules/react/jsxKey) |  MISSING DOCUMENTATION |
-| [noAccessStateInSetState](/docs/lint/rules/react/noAccessStateInSetState) |  MISSING DOCUMENTATION |
-| [noArrayIndexKey](/docs/lint/rules/react/noArrayIndexKey) |  MISSING DOCUMENTATION |
-| [noChildrenProp](/docs/lint/rules/react/noChildrenProp) |  MISSING DOCUMENTATION |
-| [noDanger](/docs/lint/rules/react/noDanger) |  MISSING DOCUMENTATION |
-| [noDangerWithChildren](/docs/lint/rules/react/noDangerWithChildren) |  MISSING DOCUMENTATION |
-| [noDidMountSetState](/docs/lint/rules/react/noDidMountSetState) |  MISSING DOCUMENTATION |
-| [noDidUpdateSetState](/docs/lint/rules/react/noDidUpdateSetState) |  MISSING DOCUMENTATION |
-| [noDirectMutationState](/docs/lint/rules/react/noDirectMutationState) |  MISSING DOCUMENTATION |
-| [noFindDOMNode](/docs/lint/rules/react/noFindDOMNode) |  MISSING DOCUMENTATION |
-| [noRedundantShouldComponentUpdate](/docs/lint/rules/react/noRedundantShouldComponentUpdate) |  MISSING DOCUMENTATION |
-| [noRenderReturnValue](/docs/lint/rules/react/noRenderReturnValue) |  MISSING DOCUMENTATION |
-| [noStringRefs](/docs/lint/rules/react/noStringRefs) |  MISSING DOCUMENTATION |
-| [noThisInSFC](/docs/lint/rules/react/noThisInSFC) |  MISSING DOCUMENTATION |
-| [noUnsafe](/docs/lint/rules/react/noUnsafe) |  MISSING DOCUMENTATION |
-| [noUselessFragment](/docs/lint/rules/react/noUselessFragment) |  MISSING DOCUMENTATION |
-| [noWillUpdateSetState](/docs/lint/rules/react/noWillUpdateSetState) |  MISSING DOCUMENTATION |
-| [requireRenderReturn](/docs/lint/rules/react/requireRenderReturn) |  MISSING DOCUMENTATION |
-| [sortComp](/docs/lint/rules/react/sortComp) |  MISSING DOCUMENTATION |
-| [stylePropObject](/docs/lint/rules/react/stylePropObject) |  MISSING DOCUMENTATION |
-| [voidDomElementsNoChildren](/docs/lint/rules/react/voidDomElementsNoChildren) |  MISSING DOCUMENTATION |
+- [camelCase](/docs/lint/rules/js/camelCase):   MISSING DOCUMENTATION
+- [caseSingleStatement](/docs/lint/rules/js/caseSingleStatement):   MISSING DOCUMENTATION
+- [confusingLanguage](/docs/lint/rules/js/confusingLanguage):   MISSING DOCUMENTATION
+- [defaultExportSameBasename](/docs/lint/rules/js/defaultExportSameBasename):   MISSING DOCUMENTATION
+- [doubleEquals](/docs/lint/rules/js/doubleEquals):   MISSING DOCUMENTATION
+- [duplicateImportSource](/docs/lint/rules/js/duplicateImportSource):   MISSING DOCUMENTATION
+- [emptyBlocks](/docs/lint/rules/js/emptyBlocks):   MISSING DOCUMENTATION
+- [emptyMatches](/docs/lint/rules/js/emptyMatches):   MISSING DOCUMENTATION
+- [getterReturn](/docs/lint/rules/js/getterReturn):   MISSING DOCUMENTATION
+- [importDefaultBasename](/docs/lint/rules/js/importDefaultBasename):   MISSING DOCUMENTATION
+- [negationElse](/docs/lint/rules/js/negationElse):   MISSING DOCUMENTATION
+- [noArguments](/docs/lint/rules/js/noArguments):   MISSING DOCUMENTATION
+- [noAsyncPromiseExecutor](/docs/lint/rules/js/noAsyncPromiseExecutor):   MISSING DOCUMENTATION
+- [noCatchAssign](/docs/lint/rules/js/noCatchAssign):   MISSING DOCUMENTATION
+- [noCommaOperator](/docs/lint/rules/js/noCommaOperator):   MISSING DOCUMENTATION
+- [noCompareNegZero](/docs/lint/rules/js/noCompareNegZero):   MISSING DOCUMENTATION
+- [noCondAssign](/docs/lint/rules/js/noCondAssign):   MISSING DOCUMENTATION
+- [noDebugger](/docs/lint/rules/js/noDebugger):   MISSING DOCUMENTATION
+- [noDelete](/docs/lint/rules/js/noDelete):   MISSING DOCUMENTATION
+- [noDeleteVars](/docs/lint/rules/js/noDeleteVars):   MISSING DOCUMENTATION
+- [noDupeArgs](/docs/lint/rules/js/noDupeArgs):   MISSING DOCUMENTATION
+- [noDuplicateCase](/docs/lint/rules/js/noDuplicateCase):   MISSING DOCUMENTATION
+- [noDuplicateGroupNamesInRegularExpressions](/docs/lint/rules/js/noDuplicateGroupNamesInRegularExpressions):   MISSING DOCUMENTATION
+- [noDuplicateKeys](/docs/lint/rules/js/noDuplicateKeys):   MISSING DOCUMENTATION
+- [noEmptyCharacterClass](/docs/lint/rules/js/noEmptyCharacterClass):   MISSING DOCUMENTATION
+- [noExtraBooleanCast](/docs/lint/rules/js/noExtraBooleanCast):   MISSING DOCUMENTATION
+- [noFunctionAssign](/docs/lint/rules/js/noFunctionAssign):   MISSING DOCUMENTATION
+- [noImportAssign](/docs/lint/rules/js/noImportAssign):   MISSING DOCUMENTATION
+- [noLabelVar](/docs/lint/rules/js/noLabelVar):   MISSING DOCUMENTATION
+- [noMultipleSpacesInRegularExpressionLiterals](/docs/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals):   MISSING DOCUMENTATION
+- [noNestedTernary](/docs/lint/rules/js/noNestedTernary):   MISSING DOCUMENTATION
+- [noPosixInRegularExpression](/docs/lint/rules/js/noPosixInRegularExpression):   MISSING DOCUMENTATION
+- [noReferenceToNonExistingGroup](/docs/lint/rules/js/noReferenceToNonExistingGroup):   MISSING DOCUMENTATION
+- [noSetterReturn](/docs/lint/rules/js/noSetterReturn):   MISSING DOCUMENTATION
+- [noShadowRestrictedNames](/docs/lint/rules/js/noShadowRestrictedNames):   MISSING DOCUMENTATION
+- [noShorthandArrayType](/docs/lint/rules/js/noShorthandArrayType):   MISSING DOCUMENTATION
+- [noTemplateCurlyInString](/docs/lint/rules/js/noTemplateCurlyInString):   MISSING DOCUMENTATION
+- [noUnsafeFinally](/docs/lint/rules/js/noUnsafeFinally):   MISSING DOCUMENTATION
+- [noUnusedTemplateLiteral](/docs/lint/rules/js/noUnusedTemplateLiteral):   MISSING DOCUMENTATION
+- [noUnusedVariables](/docs/lint/rules/js/noUnusedVariables):   MISSING DOCUMENTATION
+- [noVar](/docs/lint/rules/js/noVar):   MISSING DOCUMENTATION
+- [preferBlockStatements](/docs/lint/rules/js/preferBlockStatements):   MISSING DOCUMENTATION
+- [preferFunctionDeclarations](/docs/lint/rules/js/preferFunctionDeclarations):   MISSING DOCUMENTATION
+- [preferTemplate](/docs/lint/rules/js/preferTemplate):   MISSING DOCUMENTATION
+- [preferWhile](/docs/lint/rules/js/preferWhile):   MISSING DOCUMENTATION
+- [restrictedGlobals](/docs/lint/rules/js/restrictedGlobals):   MISSING DOCUMENTATION
+- [singleVarDeclarator](/docs/lint/rules/js/singleVarDeclarator):   MISSING DOCUMENTATION
+- [sortImportExportSpecifiers](/docs/lint/rules/js/sortImportExportSpecifiers):   MISSING DOCUMENTATION
+- [sparseArray](/docs/lint/rules/js/sparseArray):   MISSING DOCUMENTATION
+- [undeclaredVariables](/docs/lint/rules/js/undeclaredVariables):   MISSING DOCUMENTATION
+- [unsafeNegation](/docs/lint/rules/js/unsafeNegation):   MISSING DOCUMENTATION
+- [altText](/docs/lint/rules/jsx-a11y/altText):   MISSING DOCUMENTATION
+- [anchorHasContent](/docs/lint/rules/jsx-a11y/anchorHasContent):   MISSING DOCUMENTATION
+- [anchorIsValid](/docs/lint/rules/jsx-a11y/anchorIsValid):   MISSING DOCUMENTATION
+- [ariaProps](/docs/lint/rules/jsx-a11y/ariaProps):   MISSING DOCUMENTATION
+- [ariaProptypes](/docs/lint/rules/jsx-a11y/ariaProptypes):   MISSING DOCUMENTATION
+- [ariaUnsupportedElements](/docs/lint/rules/jsx-a11y/ariaUnsupportedElements):   MISSING DOCUMENTATION
+- [clickEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/clickEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [headingHasContent](/docs/lint/rules/jsx-a11y/headingHasContent):   MISSING DOCUMENTATION
+- [htmlHasLang](/docs/lint/rules/jsx-a11y/htmlHasLang):   MISSING DOCUMENTATION
+- [iframeHasTitle](/docs/lint/rules/jsx-a11y/iframeHasTitle):   MISSING DOCUMENTATION
+- [imgRedundantAlt](/docs/lint/rules/jsx-a11y/imgRedundantAlt):   MISSING DOCUMENTATION
+- [lang](/docs/lint/rules/jsx-a11y/lang):   MISSING DOCUMENTATION
+- [mediaHasCaption](/docs/lint/rules/jsx-a11y/mediaHasCaption):   MISSING DOCUMENTATION
+- [mouseEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/mouseEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [noAccessKey](/docs/lint/rules/jsx-a11y/noAccessKey):   MISSING DOCUMENTATION
+- [noAutofocus](/docs/lint/rules/jsx-a11y/noAutofocus):   MISSING DOCUMENTATION
+- [noDistractingElements](/docs/lint/rules/jsx-a11y/noDistractingElements):   MISSING DOCUMENTATION
+- [noNoninteractiveElementToInteractiveRole](/docs/lint/rules/jsx-a11y/noNoninteractiveElementToInteractiveRole):   MISSING DOCUMENTATION
+- [noNoninteractiveTabindex](/docs/lint/rules/jsx-a11y/noNoninteractiveTabindex):   MISSING DOCUMENTATION
+- [noOnChange](/docs/lint/rules/jsx-a11y/noOnChange):   MISSING DOCUMENTATION
+- [noRedundantRoles](/docs/lint/rules/jsx-a11y/noRedundantRoles):   MISSING DOCUMENTATION
+- [noTargetBlank](/docs/lint/rules/jsx-a11y/noTargetBlank):   MISSING DOCUMENTATION
+- [roleHasRequiredAriaProps](/docs/lint/rules/jsx-a11y/roleHasRequiredAriaProps):   MISSING DOCUMENTATION
+- [scope](/docs/lint/rules/jsx-a11y/scope):   MISSING DOCUMENTATION
+- [tabindexNoPositive](/docs/lint/rules/jsx-a11y/tabindexNoPositive):   MISSING DOCUMENTATION
+- [fileExtension](/docs/lint/rules/jsx/fileExtension):   MISSING DOCUMENTATION
+- [noCommentText](/docs/lint/rules/jsx/noCommentText):   MISSING DOCUMENTATION
+- [noDuplicateProps](/docs/lint/rules/jsx/noDuplicateProps):   MISSING DOCUMENTATION
+- [noImplicitBoolean](/docs/lint/rules/jsx/noImplicitBoolean):   MISSING DOCUMENTATION
+- [pascalCase](/docs/lint/rules/jsx/pascalCase):   MISSING DOCUMENTATION
+- [propsNoSpreading](/docs/lint/rules/jsx/propsNoSpreading):   MISSING DOCUMENTATION
+- [buttonHasType](/docs/lint/rules/react/buttonHasType):   MISSING DOCUMENTATION
+- [jsxFragments](/docs/lint/rules/react/jsxFragments):   MISSING DOCUMENTATION
+- [jsxKey](/docs/lint/rules/react/jsxKey):   MISSING DOCUMENTATION
+- [noAccessStateInSetState](/docs/lint/rules/react/noAccessStateInSetState):   MISSING DOCUMENTATION
+- [noArrayIndexKey](/docs/lint/rules/react/noArrayIndexKey):   MISSING DOCUMENTATION
+- [noChildrenProp](/docs/lint/rules/react/noChildrenProp):   MISSING DOCUMENTATION
+- [noDanger](/docs/lint/rules/react/noDanger):   MISSING DOCUMENTATION
+- [noDangerWithChildren](/docs/lint/rules/react/noDangerWithChildren):   MISSING DOCUMENTATION
+- [noDidMountSetState](/docs/lint/rules/react/noDidMountSetState):   MISSING DOCUMENTATION
+- [noDidUpdateSetState](/docs/lint/rules/react/noDidUpdateSetState):   MISSING DOCUMENTATION
+- [noDirectMutationState](/docs/lint/rules/react/noDirectMutationState):   MISSING DOCUMENTATION
+- [noFindDOMNode](/docs/lint/rules/react/noFindDOMNode):   MISSING DOCUMENTATION
+- [noRedundantShouldComponentUpdate](/docs/lint/rules/react/noRedundantShouldComponentUpdate):   MISSING DOCUMENTATION
+- [noRenderReturnValue](/docs/lint/rules/react/noRenderReturnValue):   MISSING DOCUMENTATION
+- [noStringRefs](/docs/lint/rules/react/noStringRefs):   MISSING DOCUMENTATION
+- [noThisInSFC](/docs/lint/rules/react/noThisInSFC):   MISSING DOCUMENTATION
+- [noUnsafe](/docs/lint/rules/react/noUnsafe):   MISSING DOCUMENTATION
+- [noUselessFragment](/docs/lint/rules/react/noUselessFragment):   MISSING DOCUMENTATION
+- [noWillUpdateSetState](/docs/lint/rules/react/noWillUpdateSetState):   MISSING DOCUMENTATION
+- [requireRenderReturn](/docs/lint/rules/react/requireRenderReturn):   MISSING DOCUMENTATION
+- [sortComp](/docs/lint/rules/react/sortComp):   MISSING DOCUMENTATION
+- [stylePropObject](/docs/lint/rules/react/stylePropObject):   MISSING DOCUMENTATION
+- [voidDomElementsNoChildren](/docs/lint/rules/react/voidDomElementsNoChildren):   MISSING DOCUMENTATION
 
 ## TypeScript
 
-| Rule | Description |
-| ------------- | ------------- |
-| [noExplicitAny](/docs/lint/rules/ts/noExplicitAny) |  MISSING DOCUMENTATION |
-| [preferInterfaces](/docs/lint/rules/ts/preferInterfaces) |  MISSING DOCUMENTATION |
+- [camelCase](/docs/lint/rules/js/camelCase):   MISSING DOCUMENTATION
+- [caseSingleStatement](/docs/lint/rules/js/caseSingleStatement):   MISSING DOCUMENTATION
+- [confusingLanguage](/docs/lint/rules/js/confusingLanguage):   MISSING DOCUMENTATION
+- [defaultExportSameBasename](/docs/lint/rules/js/defaultExportSameBasename):   MISSING DOCUMENTATION
+- [doubleEquals](/docs/lint/rules/js/doubleEquals):   MISSING DOCUMENTATION
+- [duplicateImportSource](/docs/lint/rules/js/duplicateImportSource):   MISSING DOCUMENTATION
+- [emptyBlocks](/docs/lint/rules/js/emptyBlocks):   MISSING DOCUMENTATION
+- [emptyMatches](/docs/lint/rules/js/emptyMatches):   MISSING DOCUMENTATION
+- [getterReturn](/docs/lint/rules/js/getterReturn):   MISSING DOCUMENTATION
+- [importDefaultBasename](/docs/lint/rules/js/importDefaultBasename):   MISSING DOCUMENTATION
+- [negationElse](/docs/lint/rules/js/negationElse):   MISSING DOCUMENTATION
+- [noArguments](/docs/lint/rules/js/noArguments):   MISSING DOCUMENTATION
+- [noAsyncPromiseExecutor](/docs/lint/rules/js/noAsyncPromiseExecutor):   MISSING DOCUMENTATION
+- [noCatchAssign](/docs/lint/rules/js/noCatchAssign):   MISSING DOCUMENTATION
+- [noCommaOperator](/docs/lint/rules/js/noCommaOperator):   MISSING DOCUMENTATION
+- [noCompareNegZero](/docs/lint/rules/js/noCompareNegZero):   MISSING DOCUMENTATION
+- [noCondAssign](/docs/lint/rules/js/noCondAssign):   MISSING DOCUMENTATION
+- [noDebugger](/docs/lint/rules/js/noDebugger):   MISSING DOCUMENTATION
+- [noDelete](/docs/lint/rules/js/noDelete):   MISSING DOCUMENTATION
+- [noDeleteVars](/docs/lint/rules/js/noDeleteVars):   MISSING DOCUMENTATION
+- [noDupeArgs](/docs/lint/rules/js/noDupeArgs):   MISSING DOCUMENTATION
+- [noDuplicateCase](/docs/lint/rules/js/noDuplicateCase):   MISSING DOCUMENTATION
+- [noDuplicateGroupNamesInRegularExpressions](/docs/lint/rules/js/noDuplicateGroupNamesInRegularExpressions):   MISSING DOCUMENTATION
+- [noDuplicateKeys](/docs/lint/rules/js/noDuplicateKeys):   MISSING DOCUMENTATION
+- [noEmptyCharacterClass](/docs/lint/rules/js/noEmptyCharacterClass):   MISSING DOCUMENTATION
+- [noExtraBooleanCast](/docs/lint/rules/js/noExtraBooleanCast):   MISSING DOCUMENTATION
+- [noFunctionAssign](/docs/lint/rules/js/noFunctionAssign):   MISSING DOCUMENTATION
+- [noImportAssign](/docs/lint/rules/js/noImportAssign):   MISSING DOCUMENTATION
+- [noLabelVar](/docs/lint/rules/js/noLabelVar):   MISSING DOCUMENTATION
+- [noMultipleSpacesInRegularExpressionLiterals](/docs/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals):   MISSING DOCUMENTATION
+- [noNestedTernary](/docs/lint/rules/js/noNestedTernary):   MISSING DOCUMENTATION
+- [noPosixInRegularExpression](/docs/lint/rules/js/noPosixInRegularExpression):   MISSING DOCUMENTATION
+- [noReferenceToNonExistingGroup](/docs/lint/rules/js/noReferenceToNonExistingGroup):   MISSING DOCUMENTATION
+- [noSetterReturn](/docs/lint/rules/js/noSetterReturn):   MISSING DOCUMENTATION
+- [noShadowRestrictedNames](/docs/lint/rules/js/noShadowRestrictedNames):   MISSING DOCUMENTATION
+- [noShorthandArrayType](/docs/lint/rules/js/noShorthandArrayType):   MISSING DOCUMENTATION
+- [noTemplateCurlyInString](/docs/lint/rules/js/noTemplateCurlyInString):   MISSING DOCUMENTATION
+- [noUnsafeFinally](/docs/lint/rules/js/noUnsafeFinally):   MISSING DOCUMENTATION
+- [noUnusedTemplateLiteral](/docs/lint/rules/js/noUnusedTemplateLiteral):   MISSING DOCUMENTATION
+- [noUnusedVariables](/docs/lint/rules/js/noUnusedVariables):   MISSING DOCUMENTATION
+- [noVar](/docs/lint/rules/js/noVar):   MISSING DOCUMENTATION
+- [preferBlockStatements](/docs/lint/rules/js/preferBlockStatements):   MISSING DOCUMENTATION
+- [preferFunctionDeclarations](/docs/lint/rules/js/preferFunctionDeclarations):   MISSING DOCUMENTATION
+- [preferTemplate](/docs/lint/rules/js/preferTemplate):   MISSING DOCUMENTATION
+- [preferWhile](/docs/lint/rules/js/preferWhile):   MISSING DOCUMENTATION
+- [restrictedGlobals](/docs/lint/rules/js/restrictedGlobals):   MISSING DOCUMENTATION
+- [singleVarDeclarator](/docs/lint/rules/js/singleVarDeclarator):   MISSING DOCUMENTATION
+- [sortImportExportSpecifiers](/docs/lint/rules/js/sortImportExportSpecifiers):   MISSING DOCUMENTATION
+- [sparseArray](/docs/lint/rules/js/sparseArray):   MISSING DOCUMENTATION
+- [undeclaredVariables](/docs/lint/rules/js/undeclaredVariables):   MISSING DOCUMENTATION
+- [unsafeNegation](/docs/lint/rules/js/unsafeNegation):   MISSING DOCUMENTATION
+- [altText](/docs/lint/rules/jsx-a11y/altText):   MISSING DOCUMENTATION
+- [anchorHasContent](/docs/lint/rules/jsx-a11y/anchorHasContent):   MISSING DOCUMENTATION
+- [anchorIsValid](/docs/lint/rules/jsx-a11y/anchorIsValid):   MISSING DOCUMENTATION
+- [ariaProps](/docs/lint/rules/jsx-a11y/ariaProps):   MISSING DOCUMENTATION
+- [ariaProptypes](/docs/lint/rules/jsx-a11y/ariaProptypes):   MISSING DOCUMENTATION
+- [ariaUnsupportedElements](/docs/lint/rules/jsx-a11y/ariaUnsupportedElements):   MISSING DOCUMENTATION
+- [clickEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/clickEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [headingHasContent](/docs/lint/rules/jsx-a11y/headingHasContent):   MISSING DOCUMENTATION
+- [htmlHasLang](/docs/lint/rules/jsx-a11y/htmlHasLang):   MISSING DOCUMENTATION
+- [iframeHasTitle](/docs/lint/rules/jsx-a11y/iframeHasTitle):   MISSING DOCUMENTATION
+- [imgRedundantAlt](/docs/lint/rules/jsx-a11y/imgRedundantAlt):   MISSING DOCUMENTATION
+- [lang](/docs/lint/rules/jsx-a11y/lang):   MISSING DOCUMENTATION
+- [mediaHasCaption](/docs/lint/rules/jsx-a11y/mediaHasCaption):   MISSING DOCUMENTATION
+- [mouseEventsHaveKeyEvents](/docs/lint/rules/jsx-a11y/mouseEventsHaveKeyEvents):   MISSING DOCUMENTATION
+- [noAccessKey](/docs/lint/rules/jsx-a11y/noAccessKey):   MISSING DOCUMENTATION
+- [noAutofocus](/docs/lint/rules/jsx-a11y/noAutofocus):   MISSING DOCUMENTATION
+- [noDistractingElements](/docs/lint/rules/jsx-a11y/noDistractingElements):   MISSING DOCUMENTATION
+- [noNoninteractiveElementToInteractiveRole](/docs/lint/rules/jsx-a11y/noNoninteractiveElementToInteractiveRole):   MISSING DOCUMENTATION
+- [noNoninteractiveTabindex](/docs/lint/rules/jsx-a11y/noNoninteractiveTabindex):   MISSING DOCUMENTATION
+- [noOnChange](/docs/lint/rules/jsx-a11y/noOnChange):   MISSING DOCUMENTATION
+- [noRedundantRoles](/docs/lint/rules/jsx-a11y/noRedundantRoles):   MISSING DOCUMENTATION
+- [noTargetBlank](/docs/lint/rules/jsx-a11y/noTargetBlank):   MISSING DOCUMENTATION
+- [roleHasRequiredAriaProps](/docs/lint/rules/jsx-a11y/roleHasRequiredAriaProps):   MISSING DOCUMENTATION
+- [scope](/docs/lint/rules/jsx-a11y/scope):   MISSING DOCUMENTATION
+- [tabindexNoPositive](/docs/lint/rules/jsx-a11y/tabindexNoPositive):   MISSING DOCUMENTATION
+- [fileExtension](/docs/lint/rules/jsx/fileExtension):   MISSING DOCUMENTATION
+- [noCommentText](/docs/lint/rules/jsx/noCommentText):   MISSING DOCUMENTATION
+- [noDuplicateProps](/docs/lint/rules/jsx/noDuplicateProps):   MISSING DOCUMENTATION
+- [noImplicitBoolean](/docs/lint/rules/jsx/noImplicitBoolean):   MISSING DOCUMENTATION
+- [pascalCase](/docs/lint/rules/jsx/pascalCase):   MISSING DOCUMENTATION
+- [propsNoSpreading](/docs/lint/rules/jsx/propsNoSpreading):   MISSING DOCUMENTATION
+- [buttonHasType](/docs/lint/rules/react/buttonHasType):   MISSING DOCUMENTATION
+- [jsxFragments](/docs/lint/rules/react/jsxFragments):   MISSING DOCUMENTATION
+- [jsxKey](/docs/lint/rules/react/jsxKey):   MISSING DOCUMENTATION
+- [noAccessStateInSetState](/docs/lint/rules/react/noAccessStateInSetState):   MISSING DOCUMENTATION
+- [noArrayIndexKey](/docs/lint/rules/react/noArrayIndexKey):   MISSING DOCUMENTATION
+- [noChildrenProp](/docs/lint/rules/react/noChildrenProp):   MISSING DOCUMENTATION
+- [noDanger](/docs/lint/rules/react/noDanger):   MISSING DOCUMENTATION
+- [noDangerWithChildren](/docs/lint/rules/react/noDangerWithChildren):   MISSING DOCUMENTATION
+- [noDidMountSetState](/docs/lint/rules/react/noDidMountSetState):   MISSING DOCUMENTATION
+- [noDidUpdateSetState](/docs/lint/rules/react/noDidUpdateSetState):   MISSING DOCUMENTATION
+- [noDirectMutationState](/docs/lint/rules/react/noDirectMutationState):   MISSING DOCUMENTATION
+- [noFindDOMNode](/docs/lint/rules/react/noFindDOMNode):   MISSING DOCUMENTATION
+- [noRedundantShouldComponentUpdate](/docs/lint/rules/react/noRedundantShouldComponentUpdate):   MISSING DOCUMENTATION
+- [noRenderReturnValue](/docs/lint/rules/react/noRenderReturnValue):   MISSING DOCUMENTATION
+- [noStringRefs](/docs/lint/rules/react/noStringRefs):   MISSING DOCUMENTATION
+- [noThisInSFC](/docs/lint/rules/react/noThisInSFC):   MISSING DOCUMENTATION
+- [noUnsafe](/docs/lint/rules/react/noUnsafe):   MISSING DOCUMENTATION
+- [noUselessFragment](/docs/lint/rules/react/noUselessFragment):   MISSING DOCUMENTATION
+- [noWillUpdateSetState](/docs/lint/rules/react/noWillUpdateSetState):   MISSING DOCUMENTATION
+- [requireRenderReturn](/docs/lint/rules/react/requireRenderReturn):   MISSING DOCUMENTATION
+- [sortComp](/docs/lint/rules/react/sortComp):   MISSING DOCUMENTATION
+- [stylePropObject](/docs/lint/rules/react/stylePropObject):   MISSING DOCUMENTATION
+- [voidDomElementsNoChildren](/docs/lint/rules/react/voidDomElementsNoChildren):   MISSING DOCUMENTATION
+- [noExplicitAny](/docs/lint/rules/ts/noExplicitAny):   MISSING DOCUMENTATION
+- [preferInterfaces](/docs/lint/rules/ts/preferInterfaces):   MISSING DOCUMENTATION
 

--- a/website/src/styles/_content.scss
+++ b/website/src/styles/_content.scss
@@ -13,6 +13,15 @@
     }
   }
 
+  ul {
+    padding: 0;
+    margin: 0 0 0 12px;
+
+    li {
+      margin: 4px 0;
+    }
+  }
+
   h1:hover .header-anchor,
   h2:hover .header-anchor,
   h3:hover .header-anchor {


### PR DESCRIPTION
Closes #798 

Switched to an ordered list to show the rules. I changed a bit the styles of the list to allow some gutter between list item and other, this way it's more readable.

![Screen Shot 2020-07-15 at 09 42 37](https://user-images.githubusercontent.com/602478/87524417-0e860880-c680-11ea-9139-40215d8cfb00.png)

![Screenshot_2020-07-15 Lint Rules — Rome Frontend Toolchain](https://user-images.githubusercontent.com/602478/87524442-147be980-c680-11ea-90a1-afc62cba0d4d.png)


@EduardoLopes  would you mind take a look please? 
