### PR TITLE
Website: Add search input styles

### DIFF
--- a/website/src/_includes/layouts/base.njk
+++ b/website/src/_includes/layouts/base.njk
@@ -94,58 +94,62 @@
           </ul>
         </nav>
 
-        <nav aria-labelledby="site-navigation" class="menu">
-          <h2 id="site-navigation" class="sr-only">Site Navigation</h2>
-          <input type="text" id="docusearch" placeholder="Search" />
-          <ul>
-            <li>
-              <a href="{{ '/blog' | url }}">Blog</a>
-            </li>
-            <li>
-              <a href="{{ '/contributing/team' | url }}">Team</a>
-            </li>
-            <li>
-              <a href="{{ '/contributing/philosophy' | url }}">Philosophy</a>
-            </li>
-            <li>
-              <a href="{{ '/sitemap' | url }}">Sitemap</a>
-            </li>
-          </ul>
-        </nav>
+        <input type="text" id="docusearch" placeholder="Search" />
 
-        <nav aria-labelledby="site-navigation-core-documentation" class="menu">
-          <h2 id="site-navigation-core-documentation">Core Documentation</h2>
-          <ul>
-            <li>
-              <a href="{{ '/docs/getting-started' | url }}">Getting Started</a>
-            </li>
-            <li>
-              <a href="{{ '/docs/lint' | url }}">Linting</a>
-            </li>
-          </ul>
-        </nav>
+        <div class="menu-wrapper">
+          <nav aria-labelledby="site-navigation" class="menu">
+            <h2 id="site-navigation" class="sr-only">Site Navigation</h2>
+            <ul>
+              <li>
+                <a href="{{ '/blog' | url }}">Blog</a>
+              </li>
+              <li>
+                <a href="{{ '/contributing/team' | url }}">Team</a>
+              </li>
+              <li>
+                <a href="{{ '/contributing/philosophy' | url }}">Philosophy</a>
+              </li>
+              <li>
+                <a href="{{ '/sitemap' | url }}">Sitemap</a>
+              </li>
+            </ul>
+          </nav>
 
-        <nav aria-labelledby="site-navigation-documentation" class="menu">
-          <h2 id="site-navigation-documentation">Documentation</h2>
-          <ul>
-            <li>
-              <a href="{{ '/docs/cli' | url }}">CLI</a>
-            </li>
-            <li>
-              <a href="{{ '/docs/diagnostics' | url }}">Diagnostics</a>
-            </li>
-            <li>
-              <a href="{{ '/docs/editor-integration' | url }}">Editor Integration</a>
-            </li>
-            <li>
-              <a href="{{ '/docs/language-support' | url }}">Language Support</a>
-            </li>
-            <li>
-              <a href="{{ '/docs/project-config' | url }}">Project Config</a>
-            </li>
-          </ul>
-        </nav>
+          <nav aria-labelledby="site-navigation-core-documentation" class="menu">
+            <h2 id="site-navigation-core-documentation">Core Documentation</h2>
+            <ul>
+              <li>
+                <a href="{{ '/docs/getting-started' | url }}">Getting Started</a>
+              </li>
+              <li>
+                <a href="{{ '/docs/lint' | url }}">Linting</a>
+              </li>
+            </ul>
+          </nav>
+
+          <nav aria-labelledby="site-navigation-documentation" class="menu">
+            <h2 id="site-navigation-documentation">Documentation</h2>
+            <ul>
+              <li>
+                <a href="{{ '/docs/cli' | url }}">CLI</a>
+              </li>
+              <li>
+                <a href="{{ '/docs/diagnostics' | url }}">Diagnostics</a>
+              </li>
+              <li>
+                <a href="{{ '/docs/editor-integration' | url }}">Editor Integration</a>
+              </li>
+              <li>
+                <a href="{{ '/docs/language-support' | url }}">Language Support</a>
+              </li>
+              <li>
+                <a href="{{ '/docs/project-config' | url }}">Project Config</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
+
       <div class="main">
         <div class="overlay"></div>
         {% if eleventyNavigation.key %}

--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -145,6 +145,31 @@
   }
 }
 
+// Better look on mobile
+// solution from https://github.com/algolia/docsearch/issues/181
+.algolia-autocomplete {
+
+  @include mobile-only() {
+    .ds-dropdown-menu {
+      max-width: calc(100vw - 32px) !important;
+      min-width: calc(100vw - 32px) !important;
+      width: calc(100vw - 32px) !important;
+      margin-left: 16px !important;
+    }
+    .algolia-docsearch-suggestion--content {
+      width: 100% !important;
+      padding-left: 0 !important;
+    }
+    .algolia-docsearch-suggestion--content:before  {
+      display: none !important;
+    }
+    .algolia-docsearch-suggestion--subcategory-column {
+      display: none !important;
+    }
+  }
+
+}
+
 .algolia-autocomplete, input#docusearch {
   width: 100%;
   display: block;

--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -2,8 +2,6 @@
   @include transition-timing;
   width: $sidebar-width;
   list-style: none;
-  overflow-y: auto;
-  overflow-x: hidden;
   font-size: 0.95rem;
   position: sticky;
   z-index: 99999;
@@ -68,6 +66,11 @@
 
     }
 
+  }
+
+  .menu-wrapper{
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .menu {

--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -41,6 +41,7 @@
   &.right{
     border-right: 1px solid var(--soft-border-color);
     border-left: none;
+    z-index: 0;
 
     @include desktop-only() {
       padding-top: 0;
@@ -149,14 +150,22 @@
   display: block;
 }
 
-.algolia-autocomplete {
-  padding-right: $unit * 2;
+.ds-dropdown-menu{
+  left: $unit * 2 !important;
 }
 
 input#docusearch {
-  padding: 5px;
-  border-radius: 4px;
-  border: 1px solid red;
+  padding: 32px 8px 32px 32px;
+  border: 0;
+  border-bottom: 1px solid var(--soft-border-color);
+  height: $unit * 2;
+  background: var(--background-color);
+  font-size: 1em;
+  color: var(--font-color);
+}
+
+input#docusearch::placeholder {
+  color: var(--sub-text-color);
 }
 
 html[data-theme='dark'] .color-scheme-switch:after {


### PR DESCRIPTION
This PR fix algolia dropdown hidden by `overflow-x: auto` and add styles for the search input.

Now, only the menus of the sidebar are scrollable. This is essential for mobile. On desktop, the scrollbar doesn't look good and as the menu grows, it will show all the time.

I made the sticky sidebar at first, because we were going towards make a single giant page and a sticky sidebar would be handy in that case. Now that we will not have pages that big, we should think about don't have a sticky left sidebar on desktop. c/c @sebmck 

<img src="https://user-images.githubusercontent.com/1084297/87742915-19df4e00-c7be-11ea-8dee-4afcc12a3a5c.png" width="215">
<img src="https://user-images.githubusercontent.com/1084297/87742920-1d72d500-c7be-11ea-9ab2-32b09fc4dd20.png" width="350">
<img src="https://user-images.githubusercontent.com/1084297/87742923-1f3c9880-c7be-11ea-8969-c7764fe21ba4.png" width="230">
