### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.md
+++ b/.github/ISSUE_TEMPLATE/01_bug.md
@@ -1,21 +1,30 @@
 ---
 name: '🐛 Bug Report'
-about: Report a bug or regression
-title: ''
-labels: 'bug'
+about: Report a possible bug or regression
+title: '🐛 <TITLE>'
+labels: 'bug: unconfirmed'
 ---
 
-Description:
+<!-- Bug reports that don't follow this template will be closed. -->
+<!-- Please provide a clear and concise description of what the bug is. -->
 
-    Please provide a clear and concise description of what the bug is. Include screenshots if needed.
+## Environment
+
+<!-- Run `rome rage --summary` and paste the output below. -->
+
+```
+$ rome rage --summary
+
+```
 
 ## Steps To Reproduce
 
-    Provide a detailed list of steps that reproduce the issue.
-    Issues without reproduction steps or code are likely to stall.
+<!-- Provide a detailed list of steps that reproduce the issue. -->
+<!-- The more information and included steps, the quicker your reort can be confirmed and addressed! -->
 
-1. 2.
+1. 
+2. 
 
 ## Expected Results
 
-    Describe what you expected to happen.
+<!-- Describe what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/02_misc.md
+++ b/.github/ISSUE_TEMPLATE/02_misc.md
@@ -1,0 +1,6 @@
+---
+name: '💭 Miscellaneous'
+about: Feature proposals, project meta discussion and questions, and anything else!
+title: '<TITLE>'
+labels: 'needs triage'
+---

--- a/.github/ISSUE_TEMPLATE/02_question.md
+++ b/.github/ISSUE_TEMPLATE/02_question.md
@@ -1,8 +1,0 @@
----
-name: '🤔 Question'
-about: Ask a question about the project
-title: ''
-labels: 'question'
----
-
-Hey! I have a question about the project.

--- a/.github/ISSUE_TEMPLATE/03_support.md
+++ b/.github/ISSUE_TEMPLATE/03_support.md
@@ -1,8 +1,0 @@
----
-name: '🚑 Support'
-about: Ask for usage support
-title: ''
-labels: 'support'
----
-
-Hey! I'm having trouble with something.

--- a/.github/ISSUE_TEMPLATE/03_task.md
+++ b/.github/ISSUE_TEMPLATE/03_task.md
@@ -1,0 +1,6 @@
+---
+name: '🚀 Task'
+about: Specific actionable task. Typically opened by existing contributors. If you aren't sure then use the "Miscellaneous" template.
+title: '🚀 <TITLE>'
+labels: 'task'
+---

--- a/.github/ISSUE_TEMPLATE/04_task.md
+++ b/.github/ISSUE_TEMPLATE/04_task.md
@@ -1,6 +1,0 @@
----
-name: '🚀 Task'
-about: Actionable tasks to do something
-title: ''
-labels: ''
----

--- a/.github/ISSUE_TEMPLATE/04_umbrella.md
+++ b/.github/ISSUE_TEMPLATE/04_umbrella.md
@@ -1,0 +1,6 @@
+---
+name: '☂️ Umbrella'
+about: Discuss and track high level goals for a collection of other issues. Should only be opened with prior discussion.
+title: '☂️ <TITLE>'
+labels: 'task'
+---

--- a/.github/ISSUE_TEMPLATE/05_discussion.md
+++ b/.github/ISSUE_TEMPLATE/05_discussion.md
@@ -1,6 +1,0 @@
----
-name: '🗣️ Discussion'
-about: Start a discussion
-title: ''
-labels: 'discussion'
----

--- a/.github/ISSUE_TEMPLATE/06_umbrella.md
+++ b/.github/ISSUE_TEMPLATE/06_umbrella.md
@@ -1,6 +1,0 @@
----
-name: '☂️ Umbrella'
-about: A task to track a collection of other tasks
-title: '☂️ '
-labels: 'umbrella'
----

--- a/.github/ISSUE_TEMPLATE/07_other.md
+++ b/.github/ISSUE_TEMPLATE/07_other.md
@@ -1,6 +1,0 @@
----
-name: '💭 Other'
-about: Issues that don't fit under anything else
-title: ''
-labels: ''
----

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🗣️ Chat
+    url: https://discord.gg/rome
+    about: Our Discord server is active and is used for real-time discussions including contribution collaboratio, questions, and more!
+  - name: 🤔 Support
+    url: https://discord.gg/rome
+    about: "This issue tracker is not for support questions. Visit our community Discord and the #support channel for assistance!"
+  - name: 🆘 Code of Conduct Reports
+    url: https://github.com/romefrontend/rome/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct
+    about: Please use the contact information in `CODE_OF_CONDUCT.md` as issues created here are public


### PR DESCRIPTION
This PR updates our issue templates. They are now only four that I considered to be the most relevant:

 - 🐛 Bug Report: "Report a possible bug or regression"
 - 💭 Miscellaneous: "Feature proposals, project meta discussion and questions, and anything else!"
 - 🚀 Task: "Specific actionable task. Typically opened by existing contributors. If you aren't sure then use the "Miscellaneous" template."
 - ☔  Umbrella: "Discuss and track high level goals for a collection of other issues. Should only be opened with prior discussion."

I wanted to make these concise and general to avoid information overload. The last two are only relevant for contributors (including those not core). While the top two are aimed at general users.

I also included these links under these the issue templates:

- [🗣️ Chat](https://discord.gg/rome): "Our Discord server is active and is used for real-time discussions including collaboration, questions, and more!
- [🤔 Support](https://discord.gg/rome): "This issue tracker is not for support questions. Visit our community Discord and the #support channel for assistance!"
- [🆘 Code of Conduct Reports](https://github.com/romefrontend/rome/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct): "Please use the contact information in our Code of Conduct as issues created here are public"

Previously I thought it would be best to include questions and support issues in this repo. But I think that will get overwhelming fast and we should keep this high signal. Discord is great for real-time discussion and support, but long-term it's not practical as a documentation source for common issues. When that happens though we can recommend another support forum such as Stack Overflow, or we could include problem solving pages on our website and create issues here to track website additions.

Resolves #732