### PR TITLE
Add `rome rage --summary`

### DIFF
--- a/packages/@romefrontend/cli/cli.ts
+++ b/packages/@romefrontend/cli/cli.ts
@@ -361,7 +361,14 @@ export default async function cli() {
 		name: "rage",
 		category: commandCategories.INTERNAL,
 		description: "TODO",
-		callback() {
+		defineFlags(c) {
+			return {
+				summary: c.get("summary").asBoolean(false),
+			};
+		},
+		callback(_commandFlags) {
+			commandFlags = _commandFlags;
+
 			overrideCLIFlags = {
 				rage: true,
 			};
@@ -434,11 +441,17 @@ export default async function cli() {
 		};
 
 		if (cliFlags.rage) {
-			const {ragePath} = cliFlags;
-			const filename = clientFlags.cwd.resolve(
-				ragePath === undefined ? `Rage-${getFilenameTimestamp()}.tgz` : ragePath,
-			).join();
-			await client.rage(filename, profileOptions);
+			if (commandFlags.summary === true) {
+				client.reporter.logAll(await client.generateRageSummary());
+			} else {
+				const {ragePath} = cliFlags;
+				const filename = clientFlags.cwd.resolve(
+					ragePath === undefined
+						? `Rage-${getFilenameTimestamp()}.tgz`
+						: ragePath,
+				).join();
+				await client.rage(filename, profileOptions);
+			}
 			return;
 		}
 

--- a/packages/@romefrontend/core/client/Client.ts
+++ b/packages/@romefrontend/core/client/Client.ts
@@ -364,7 +364,12 @@ export default class Client {
 		}
 		push("Environment Variables", env);
 
-		push("User Config", (getUserConfigFile()?.consumer).asUnknown());
+		const userConfig = getUserConfigFile();
+		push(
+			"User Config",
+			userConfig === undefined ? "unset" : userConfig.consumer.asUnknown(),
+		);
+
 		push("Rome Version", VERSION);
 		push("Node Version", process.versions.node);
 		push("Platform", `${process.platform} ${process.arch} ${os.release()}`);

--- a/packages/@romefrontend/core/client/Client.ts
+++ b/packages/@romefrontend/core/client/Client.ts
@@ -33,20 +33,26 @@ import {VERSION} from "../common/constants";
 import {TarWriter} from "@romefrontend/codec-tar";
 import {Profile, Profiler, Trace, TraceEvent} from "@romefrontend/v8";
 import {PartialServerQueryRequest} from "../common/bridges/ServerBridge";
-import {UserConfig, loadUserConfig} from "../common/userConfig";
+import {
+	UserConfig,
+	getUserConfigFile,
+	loadUserConfig,
+} from "../common/userConfig";
 import {removeFile} from "@romefrontend/fs";
 import {stringifyJSON} from "@romefrontend/codec-json";
 import stream = require("stream");
 import net = require("net");
 import zlib = require("zlib");
 import fs = require("fs");
+import os = require("os");
 import child = require("child_process");
-import {mergeObjects} from "@romefrontend/typescript-helpers";
+import {Dict, mergeObjects} from "@romefrontend/typescript-helpers";
 import {
 	joinMarkupLines,
 	markupToHtml,
 	markupToPlainText,
 } from "@romefrontend/cli-layout/format";
+import {escapeMarkup} from "@romefrontend/cli-layout";
 
 export function getFilenameTimestamp(): string {
 	return new Date().toISOString().replace(/[^0-9a-zA-Z]/g, "");
@@ -312,6 +318,77 @@ export default class Client {
 		});
 	}
 
+	async generateRageSummary(): Promise<string> {
+		let summary = "";
+
+		function push(name: string, value: unknown) {
+			const formatted =
+				typeof value === "string"
+					? escapeMarkup(value)
+					: prettyFormat(
+							value,
+							{
+								compact: true,
+								markup: true,
+							},
+						);
+			summary += `<emphasis>${name}</emphasis>\n<indent>${formatted}</indent>\n\n`;
+		}
+
+		const envVars: Array<string> = [
+			"PATH",
+			"ROME_CACHE",
+			"USER",
+			"LANG",
+			"COLORFGBG",
+
+			// Variables used by process.stdout.getColorDepth
+			"FORCE_COLOR",
+			"NODE_DISABLE_COLORS",
+			"NO_COLOR",
+			"TERM",
+			"TMUX",
+			"CI",
+			"TRAVIS",
+			"CIRCLECI",
+			"APPVEYOR",
+			"GITLAB_CI",
+			"CI_NAME",
+			"TEAMCITY_VERSION",
+			"TERM_PROGRAM",
+			"COLORTERM",
+		];
+		const env: Dict<string | undefined> = {};
+		for (const key of envVars) {
+			env[key] = process.env[key];
+		}
+		push("Environment Variables", env);
+
+		push("User Config", (getUserConfigFile()?.consumer).asUnknown());
+		push("Rome Version", VERSION);
+		push("Node Version", process.versions.node);
+		push("Platform", `${process.platform} ${process.arch} ${os.release()}`);
+		push("Terminal Features", this.derivedReporterStreams.features);
+		push("Client Flags", this.getClientJSONFlags());
+
+		// Don't do this if we never connected to the server
+		const bridgeStatus = this.getBridgeStatus();
+		if (bridgeStatus !== undefined) {
+			const status = await this.query(
+				{
+					silent: true,
+					commandName: "status",
+				},
+				"server",
+			);
+			if (status.type === "SUCCESS") {
+				push("Server Status", status.data);
+			}
+		}
+
+		return summary;
+	}
+
 	async rage(ragePath: string, profileOpts: ClientProfileOptions) {
 		const {bridge} = this.assertBridgeStatus();
 
@@ -376,48 +453,10 @@ export default class Client {
 				);
 			}
 
-			function indent(val: unknown): string {
-				const str =
-					typeof val === "string"
-						? val
-						: prettyFormat(
-								val,
-								{
-									compact: true,
-								},
-							);
-				const lines = str.trim().split("\n");
-				const indented = lines.join("\n  ");
-				return `\n  ${indented}`;
-			}
-
-			const env = [];
-
-			env.push(`PATH: ${indent(process.env.PATH)}`);
-			env.push(`Rome Version: ${indent(VERSION)}`);
-			env.push(`Node Version: ${indent(process.versions.node)}`);
-			env.push(`Platform: ${indent(`${process.platform} ${process.arch}`)}`);
-			env.push(
-				`Terminal Features: ${indent(this.derivedReporterStreams.features)}`,
+			writer.append(
+				{name: "summary.txt"},
+				joinMarkupLines(markupToPlainText(await this.generateRageSummary())),
 			);
-			env.push(`Client Flags: ${indent(this.getClientJSONFlags())}`);
-
-			// Don't do this if we never connected to the server
-			const bridgeStatus = this.getBridgeStatus();
-			if (bridgeStatus !== undefined) {
-				const status = await this.query(
-					{
-						silent: true,
-						commandName: "status",
-					},
-					"server",
-				);
-				if (status.type === "SUCCESS") {
-					env.push(`Server Status: ${indent(status.data)}`);
-				}
-			}
-
-			writer.append({name: "environment.txt"}, `${env.join("\n\n")}\n`);
 
 			await writer.finalize();
 			this.reporter.success(

--- a/packages/@romefrontend/core/common/userConfig.ts
+++ b/packages/@romefrontend/core/common/userConfig.ts
@@ -64,11 +64,12 @@ export function normalizeUserConfig(
 
 let loadedUserConfig: undefined | UserConfig;
 
-export function loadUserConfig(): UserConfig {
-	if (loadedUserConfig !== undefined) {
-		return loadedUserConfig;
-	}
-
+export function getUserConfigFile():
+	| undefined
+	| {
+			consumer: Consumer;
+			configPath: AbsoluteFilePath;
+		} {
 	for (const configFilename of ROME_CONFIG_FILENAMES) {
 		const configPath = HOME_PATH.appendList(".config", configFilename);
 
@@ -81,11 +82,23 @@ export function loadUserConfig(): UserConfig {
 			path: configPath,
 			input: configFile,
 		});
+		return {consumer, configPath};
+	}
 
-		loadedUserConfig = normalizeUserConfig(consumer, configPath);
+	return undefined;
+}
+
+export function loadUserConfig(): UserConfig {
+	if (loadedUserConfig !== undefined) {
 		return loadedUserConfig;
 	}
 
-	loadedUserConfig = DEFAULT_USER_CONFIG;
-	return loadedUserConfig;
+	const res = getUserConfigFile();
+	if (res === undefined) {
+		loadedUserConfig = DEFAULT_USER_CONFIG;
+		return loadedUserConfig;
+	} else {
+		loadedUserConfig = normalizeUserConfig(res.consumer, res.configPath);
+		return loadedUserConfig;
+	}
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR adds `--summary` flag to `rome rage`. We will require all bug reports to contain the output of `rome rage --summary` so we can better triage and address them.

When ran, the command will output environmental information that will be useful in figuring out if a bug is specific to someones system and configuration.

We will also populate `summary.txt` with the same output in an archive when ran with `rome rage` without the `--summary` flag.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
```
$ ./rome rage --summary
Environment Variables
  Object {
    COLORFGBG: "15;0"
    COLORTERM: "truecolor"
    PATH: "/Users/sebastianmckenzie/.nvm/versions/node/v14.2.0/bin:/Users/sebastianmckenzie/bin:/Users/sebastianmckenzie/.cargo/bin:./node_modules/.bin:/Applications/Visual
  Studio Code.app/Contents/Resources/app/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
    TERM: "xterm-256color"
    TERM_PROGRAM: "iTerm.app"
  }

User Config
  Object {}

Rome Version
  0.0.26-dev

Node Version
  14.2.0

Platform
  darwin x64 19.5.0

Terminal Features
  Object {
    background: "dark"
    colorDepth: 24
    columns: 178
    cursor: true
    hyperlinks: true
    isTTY: true
    unicode: true
  }

Client Flags
  Object {
    clientName: "cli"
    cwd: "/Users/sebastianmckenzie/Projects/rome"
    silent: false
  }
```