### PR TITLE
Defer internal script

### DIFF
--- a/website/src/_includes/layouts/base.njk
+++ b/website/src/_includes/layouts/base.njk
@@ -254,7 +254,7 @@
 			</div>
 		</footer>
 
-		<script src="{{ '/js/index.js' | url }}"></script>
+		<script defer async src="{{ '/js/index.js' | url }}"></script>
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 		<script type="text/javascript">
 			docsearch({


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Defer internal script to avoid blocking the rendering

I really don't like how the docsearch.js from algolia is set up. They don't provide any async way to set up their script. The every moment we try to make the loading of the script async, it breaks
