### PR TITLE
Convert AST types from intersections to interfaces

### DIFF
--- a/packages/@romefrontend/ast/base.ts
+++ b/packages/@romefrontend/ast/base.ts
@@ -9,16 +9,16 @@ import {AnyComment} from "@romefrontend/ast";
 import {Diagnostics} from "@romefrontend/diagnostics";
 import {NodeBase} from "@romefrontend/parser-core";
 
-export type NodeBaseWithComments = NodeBase & {
+export interface NodeBaseWithComments extends NodeBase {
 	leadingComments?: Array<string>;
 	trailingComments?: Array<string>;
 	innerComments?: Array<string>;
-};
+}
 
-export type RootBase = {
+export interface RootBase {
 	comments: Array<AnyComment>;
 	filename: string;
 	diagnostics: Diagnostics;
 	mtime: undefined | number;
 	corrupt: boolean;
-};
+}

--- a/packages/@romefrontend/ast/common/comments/CommentBlock.ts
+++ b/packages/@romefrontend/ast/common/comments/CommentBlock.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type CommentBlock = NodeBaseWithComments & {
+export interface CommentBlock extends NodeBaseWithComments {
 	type: "CommentBlock";
 	value: string;
 	id: string;
-};
+}
 
 export const jsCommentBlock = createBuilder<CommentBlock>(
 	"CommentBlock",

--- a/packages/@romefrontend/ast/common/comments/CommentLine.ts
+++ b/packages/@romefrontend/ast/common/comments/CommentLine.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type CommentLine = NodeBaseWithComments & {
+export interface CommentLine extends NodeBaseWithComments {
 	type: "CommentLine";
 	value: string;
 	id: string;
-};
+}
 
 export const jsCommentLine = createBuilder<CommentLine>(
 	"CommentLine",

--- a/packages/@romefrontend/ast/common/core/MockParent.ts
+++ b/packages/@romefrontend/ast/common/core/MockParent.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MockParent = NodeBaseWithComments & {
+export interface MockParent extends NodeBaseWithComments {
 	type: "MockParent";
-};
+}
 
 export const jsMockParent = createBuilder<MockParent>(
 	"MockParent",

--- a/packages/@romefrontend/ast/css/at-rules/CSSCharSetAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSCharSetAtStatement.ts
@@ -2,10 +2,10 @@ import {CSSStringType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @charset "UTF-8";
-export type CSSCharSetAtStatement = NodeBaseWithComments & {
+export interface CSSCharSetAtStatement extends NodeBaseWithComments {
 	type: "CSSCharSetAtStatement";
 	charset: CSSStringType;
-};
+}
 
 export const cssCharSetAtStatement = createBuilder<CSSCharSetAtStatement>(
 	"CSSCharSetAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSCounterStyleAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSCounterStyleAtStatement.ts
@@ -6,12 +6,12 @@ import {
 import {createBuilder} from "../../utils";
 
 // @counter-style
-export type CSSCounterStyleAtStatement = NodeBaseWithComments & {
+export interface CSSCounterStyleAtStatement extends NodeBaseWithComments {
 	type: "CSSCounterStyleAtStatement";
 	name: CSSIdentifierType;
 	declarations: Array<CSSRuleDeclaration>;
 	// TODO should we have a field for each known valid @counter-style property?
-};
+}
 
 export const cssCounterStyleAtStatement = createBuilder<CSSCounterStyleAtStatement>(
 	"CSSCounterStyleAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSDocumentAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSDocumentAtStatement.ts
@@ -2,11 +2,11 @@ import {AnyCSSRuleStatement, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @document
-export type CSSDocumentAtStatement = NodeBaseWithComments & {
+export interface CSSDocumentAtStatement extends NodeBaseWithComments {
 	type: "CSSDocumentAtStatement";
 	body: Array<AnyCSSRuleStatement>;
 	// TODO head properties
-};
+}
 
 export const cssDocumentAtStatement = createBuilder<CSSDocumentAtStatement>(
 	"CSSDocumentAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSFontFaceAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSFontFaceAtStatement.ts
@@ -2,11 +2,11 @@ import {CSSRuleDeclaration, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @font-face
-export type CSSFontFaceAtStatement = NodeBaseWithComments & {
+export interface CSSFontFaceAtStatement extends NodeBaseWithComments {
 	type: "CSSFontFaceAtStatement";
 	declarations: Array<CSSRuleDeclaration>;
 	// TODO should we have a field for each known valid @font-face property?
-};
+}
 
 export const cssFontFaceAtStatement = createBuilder<CSSFontFaceAtStatement>(
 	"CSSFontFaceAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSImportAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSImportAtStatement.ts
@@ -7,12 +7,12 @@ import {createBuilder} from "../../utils";
 // @import url("chrome://communicator/skin/");
 // @import "common.css" screen;
 // @import url('landscape.css') screen and (orientation:landscape);
-export type CSSImportAtStatement = NodeBaseWithComments & {
+export interface CSSImportAtStatement extends NodeBaseWithComments {
 	type: "CSSImportAtStatement";
 	url: CSSURLType | CSSStringType;
 	// TODO media queries
 	// TODO supports query
-};
+}
 
 export const cssImportAtStatement = createBuilder<CSSImportAtStatement>(
 	"CSSImportAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSKeyframesAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSKeyframesAtStatement.ts
@@ -7,11 +7,11 @@ import {
 import {createBuilder} from "../../utils";
 
 // @keyframes
-export type CSSKeyframesAtStatement = NodeBaseWithComments & {
+export interface CSSKeyframesAtStatement extends NodeBaseWithComments {
 	type: "CSSKeyframesAtStatement";
 	name: CSSIdentifierType | CSSStringType;
 	body: Array<CSSKeyframesRuleDeclaration>;
-};
+}
 
 export const cssKeyframesAtStatement = createBuilder<CSSKeyframesAtStatement>(
 	"CSSKeyframesAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSMediaAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSMediaAtStatement.ts
@@ -2,11 +2,11 @@ import {AnyCSSRuleStatement, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @media
-export type CSSMediaAtStatement = NodeBaseWithComments & {
+export interface CSSMediaAtStatement extends NodeBaseWithComments {
 	type: "CSSMediaAtStatement";
 	body: Array<AnyCSSRuleStatement>;
 	// TODO media query list
-};
+}
 
 export const cssMediaAtStatement = createBuilder<CSSMediaAtStatement>(
 	"CSSMediaAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSNamespaceAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSNamespaceAtStatement.ts
@@ -8,11 +8,11 @@ import {createBuilder} from "../../utils";
 
 // @namespace url(http://www.w3.org/1999/xhtml);
 // @namespace svg url(http://www.w3.org/2000/svg);
-export type CSSNamespaceAtStatement = NodeBaseWithComments & {
+export interface CSSNamespaceAtStatement extends NodeBaseWithComments {
 	type: "CSSNamespaceAtStatement";
 	namespace?: CSSStringType | CSSURLType;
 	prefix?: CSSIdentifierType;
-};
+}
 
 export const cssNamespaceAtStatement = createBuilder<CSSNamespaceAtStatement>(
 	"CSSNamespaceAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSPageAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSPageAtStatement.ts
@@ -2,12 +2,12 @@ import {CSSRuleDeclaration, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @page
-export type CSSPageAtStatement = NodeBaseWithComments & {
+export interface CSSPageAtStatement extends NodeBaseWithComments {
 	type: "CSSPageAtStatement";
 	// TODO pseudo property
 	declarations: Array<CSSRuleDeclaration>;
 	// TODO should we have a field for each known valid @page property?
-};
+}
 
 export const cssPageAtStatement = createBuilder<CSSPageAtStatement>(
 	"CSSPageAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSSupportsAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSSupportsAtStatement.ts
@@ -2,11 +2,11 @@ import {AnyCSSRuleStatement, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // @supports
-export type CSSSupportsAtStatement = NodeBaseWithComments & {
+export interface CSSSupportsAtStatement extends NodeBaseWithComments {
 	type: "CSSSupportsAtStatement";
 	body: Array<AnyCSSRuleStatement>;
 	// TODO supports condition
-};
+}
 
 export const cssSupportsAtStatement = createBuilder<CSSSupportsAtStatement>(
 	"CSSSupportsAtStatement",

--- a/packages/@romefrontend/ast/css/at-rules/CSSViewportAtStatement.ts
+++ b/packages/@romefrontend/ast/css/at-rules/CSSViewportAtStatement.ts
@@ -2,9 +2,9 @@ import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // TODO @viewport - Only in Edge/IE, do we want this?
-export type CSSViewportAtStatement = NodeBaseWithComments & {
+export interface CSSViewportAtStatement extends NodeBaseWithComments {
 	type: "CSSViewportAtStatement";
-};
+}
 
 export const cssViewportAtStatement = createBuilder<CSSViewportAtStatement>(
 	"CSSViewportAtStatement",

--- a/packages/@romefrontend/ast/css/core/CSSRoot.ts
+++ b/packages/@romefrontend/ast/css/core/CSSRoot.ts
@@ -1,11 +1,11 @@
 import {AnyCSSRuleStatement, NodeBaseWithComments, RootBase} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSRoot = NodeBaseWithComments &
-	RootBase & {
-		type: "CSSRoot";
-		body: Array<AnyCSSRuleStatement>;
-	};
+export interface CSSRoot extends NodeBaseWithComments,
+RootBase {
+	type: "CSSRoot";
+	body: Array<AnyCSSRuleStatement>;
+}
 
 export const cssRoot = createBuilder<CSSRoot>(
 	"CSSRoot",

--- a/packages/@romefrontend/ast/css/core/CSSRuleDeclaration.ts
+++ b/packages/@romefrontend/ast/css/core/CSSRuleDeclaration.ts
@@ -2,12 +2,12 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // foo: bar;
-export type CSSRuleDeclaration = NodeBaseWithComments & {
+export interface CSSRuleDeclaration extends NodeBaseWithComments {
 	type: "CSSRuleDeclaration";
 	key: CSSIdentifierType;
 	// TODO structured `value`
 	value: string;
-};
+}
 
 export const cssRuleDeclaration = createBuilder<CSSRuleDeclaration>(
 	"CSSRuleDeclaration",

--- a/packages/@romefrontend/ast/css/core/CSSRulesetStatement.ts
+++ b/packages/@romefrontend/ast/css/core/CSSRulesetStatement.ts
@@ -6,11 +6,11 @@ import {
 import {createBuilder} from "../../utils";
 
 // foo {}
-export type CSSRulesetStatement = NodeBaseWithComments & {
+export interface CSSRulesetStatement extends NodeBaseWithComments {
 	type: "CSSRulesetStatement";
 	selectors: Array<AnyCSSSelector>;
 	declarations: Array<CSSRuleDeclaration>;
-};
+}
 
 export const cssRulesetStatement = createBuilder<CSSRulesetStatement>(
 	"CSSRulesetStatement",

--- a/packages/@romefrontend/ast/css/keyframes/CSSKeyframesFromKeyword.ts
+++ b/packages/@romefrontend/ast/css/keyframes/CSSKeyframesFromKeyword.ts
@@ -1,9 +1,9 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSKeyframesFromKeyword = NodeBaseWithComments & {
+export interface CSSKeyframesFromKeyword extends NodeBaseWithComments {
 	type: "CSSKeyframesFromKeyword";
-};
+}
 
 export const cssKeyframesFromKeyword = createBuilder<CSSKeyframesFromKeyword>(
 	"CSSKeyframesFromKeyword",

--- a/packages/@romefrontend/ast/css/keyframes/CSSKeyframesRuleDeclaration.ts
+++ b/packages/@romefrontend/ast/css/keyframes/CSSKeyframesRuleDeclaration.ts
@@ -7,11 +7,11 @@ import {
 } from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSKeyframesRuleDeclaration = NodeBaseWithComments & {
+export interface CSSKeyframesRuleDeclaration extends NodeBaseWithComments {
 	type: "CSSKeyframesRuleDeclaration";
 	selector: CSSPercentageType | CSSKeyframesFromKeyword | CSSKeyframesToKeyword;
 	declarations: Array<CSSRuleDeclaration>;
-};
+}
 
 export const cssKeyframesRuleDeclaration = createBuilder<CSSKeyframesRuleDeclaration>(
 	"CSSKeyframesRuleDeclaration",

--- a/packages/@romefrontend/ast/css/keyframes/CSSKeyframesToKeyword.ts
+++ b/packages/@romefrontend/ast/css/keyframes/CSSKeyframesToKeyword.ts
@@ -1,9 +1,9 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSKeyframesToKeyword = NodeBaseWithComments & {
+export interface CSSKeyframesToKeyword extends NodeBaseWithComments {
 	type: "CSSKeyframesToKeyword";
-};
+}
 
 export const cssKeyframesToKeyword = createBuilder<CSSKeyframesToKeyword>(
 	"CSSKeyframesToKeyword",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorAttribute.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorAttribute.ts
@@ -4,7 +4,7 @@ import {createBuilder} from "../../utils";
 // [foo]
 // [foo=bar]
 // [foo^=bar]
-export type CSSSelectorAttribute = NodeBaseWithComments & {
+export interface CSSSelectorAttribute extends NodeBaseWithComments {
 	type: "CSSSelectorAttribute";
 	name: CSSIdentifierType;
 	value: undefined | string;
@@ -16,7 +16,7 @@ export type CSSSelectorAttribute = NodeBaseWithComments & {
 		| "suffix"
 		| "contains";
 	caseSensitive?: boolean;
-};
+}
 
 export const cssSelectorAttribute = createBuilder<CSSSelectorAttribute>(
 	"CSSSelectorAttribute",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorChain.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorChain.ts
@@ -6,12 +6,12 @@ import {
 import {createBuilder} from "../../utils";
 
 // foo#bar.yes
-export type CSSSelectorChain = NodeBaseWithComments & {
+export interface CSSSelectorChain extends NodeBaseWithComments {
 	type: "CSSSelectorChain";
 	// Can only be one per chain and must appear at the start
 	tagName: undefined | CSSSelectorTag;
 	selectors: Array<Exclude<AnyCSSSelector, CSSSelectorTag | CSSSelectorChain>>;
-};
+}
 
 export const cssSelectorChain = createBuilder<CSSSelectorChain>(
 	"CSSSelectorChain",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorClass.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorClass.ts
@@ -2,10 +2,10 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // .foo
-export type CSSSelectorClass = NodeBaseWithComments & {
+export interface CSSSelectorClass extends NodeBaseWithComments {
 	type: "CSSSelectorClass";
 	className: CSSIdentifierType;
-};
+}
 
 export const cssSelectorClass = createBuilder<CSSSelectorClass>(
 	"CSSSelectorClass",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorCombinator.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorCombinator.ts
@@ -4,7 +4,7 @@ import {createBuilder} from "../../utils";
 // foo > bar
 // foo bar
 // foo + bar
-export type CSSSelectorCombinator = NodeBaseWithComments & {
+export interface CSSSelectorCombinator extends NodeBaseWithComments {
 	type: "CSSSelectorCombinator";
 	kind:
 		| "descendant"
@@ -14,7 +14,7 @@ export type CSSSelectorCombinator = NodeBaseWithComments & {
 		| "column";
 	left: AnyCSSSelector;
 	right: AnyCSSSelector;
-};
+}
 
 export const cssSelectorCombinator = createBuilder<CSSSelectorCombinator>(
 	"CSSSelectorCombinator",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorId.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorId.ts
@@ -2,10 +2,10 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // #foo
-export type CSSSelectorId = NodeBaseWithComments & {
+export interface CSSSelectorId extends NodeBaseWithComments {
 	type: "CSSSelectorId";
 	id: CSSIdentifierType;
-};
+}
 
 export const cssSelectorId = createBuilder<CSSSelectorId>(
 	"CSSSelectorId",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorPseudoClass.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorPseudoClass.ts
@@ -2,10 +2,10 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // :hover
-export type CSSSelectorPseudoClass = NodeBaseWithComments & {
+export interface CSSSelectorPseudoClass extends NodeBaseWithComments {
 	type: "CSSSelectorPseudoClass";
 	name: CSSIdentifierType;
-};
+}
 
 export const cssSelectorPseudoClass = createBuilder<CSSSelectorPseudoClass>(
 	"CSSSelectorPseudoClass",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorPseudoElementSelector.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorPseudoElementSelector.ts
@@ -2,10 +2,10 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // ::after
-export type CSSSelectorPseudoElementSelector = NodeBaseWithComments & {
+export interface CSSSelectorPseudoElementSelector extends NodeBaseWithComments {
 	type: "CSSSelectorPseudoElementSelector";
 	name: CSSIdentifierType;
-};
+}
 
 export const cssSelectorPseudoElementSelector = createBuilder<CSSSelectorPseudoElementSelector>(
 	"CSSSelectorPseudoElementSelector",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorTag.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorTag.ts
@@ -2,10 +2,10 @@ import {CSSIdentifierType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // foo
-export type CSSSelectorTag = NodeBaseWithComments & {
+export interface CSSSelectorTag extends NodeBaseWithComments {
 	type: "CSSSelectorTag";
 	tagName: CSSIdentifierType;
-};
+}
 
 export const cssSelectorTag = createBuilder<CSSSelectorTag>(
 	"CSSSelectorTag",

--- a/packages/@romefrontend/ast/css/selectors/CSSSelectorUniversal.ts
+++ b/packages/@romefrontend/ast/css/selectors/CSSSelectorUniversal.ts
@@ -2,9 +2,9 @@ import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
 // *
-export type CSSSelectorUniversal = NodeBaseWithComments & {
+export interface CSSSelectorUniversal extends NodeBaseWithComments {
 	type: "CSSSelectorUniversal";
-};
+}
 
 export const cssSelectorUniversal = createBuilder<CSSSelectorUniversal>(
 	"CSSSelectorUniversal",

--- a/packages/@romefrontend/ast/css/types/CSSAnglePercentageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSAnglePercentageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSAnglePercentageType = NodeBaseWithComments & {
+export interface CSSAnglePercentageType extends NodeBaseWithComments {
 	type: "CSSAnglePercentageType";
 	// TODO
-};
+}
 
 export const cssAnglePercentageType = createBuilder<CSSAnglePercentageType>(
 	"CSSAnglePercentageType",

--- a/packages/@romefrontend/ast/css/types/CSSAngleType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSAngleType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSAngleType = NodeBaseWithComments & {
+export interface CSSAngleType extends NodeBaseWithComments {
 	type: "CSSAngleType";
 	// TODO
-};
+}
 
 export const cssAngleType = createBuilder<CSSAngleType>(
 	"CSSAngleType",

--- a/packages/@romefrontend/ast/css/types/CSSBasicShapeType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSBasicShapeType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSBasicShapeType = NodeBaseWithComments & {
+export interface CSSBasicShapeType extends NodeBaseWithComments {
 	type: "CSSBasicShapeType";
 	// TODO
-};
+}
 
 export const ccssBasicShapeType = createBuilder<CSSBasicShapeType>(
 	"CSSBasicShapeType",

--- a/packages/@romefrontend/ast/css/types/CSSBlendModeType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSBlendModeType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSBlendModeType = NodeBaseWithComments & {
+export interface CSSBlendModeType extends NodeBaseWithComments {
 	type: "CSSBlendModeType";
 	// TODO
-};
+}
 
 export const cssBlendModeType = createBuilder<CSSBlendModeType>(
 	"CSSBlendModeType",

--- a/packages/@romefrontend/ast/css/types/CSSDimensionType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSDimensionType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSDimensionType = NodeBaseWithComments & {
+export interface CSSDimensionType extends NodeBaseWithComments {
 	type: "CSSDimensionType";
 	// TODO
-};
+}
 
 export const cssDimensionType = createBuilder<CSSDimensionType>(
 	"CSSDimensionType",

--- a/packages/@romefrontend/ast/css/types/CSSFrequencyPercentageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSFrequencyPercentageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSFrequencyPercentageType = NodeBaseWithComments & {
+export interface CSSFrequencyPercentageType extends NodeBaseWithComments {
 	type: "CSSFrequencyPercentageType";
 	// TODO
-};
+}
 
 export const cssFrequencyPercentageType = createBuilder<CSSFrequencyPercentageType>(
 	"CSSFrequencyPercentageType",

--- a/packages/@romefrontend/ast/css/types/CSSFrequencyType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSFrequencyType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSFrequencyType = NodeBaseWithComments & {
+export interface CSSFrequencyType extends NodeBaseWithComments {
 	type: "CSSFrequencyType";
 	// TODO
-};
+}
 
 export const cssFrequencyType = createBuilder<CSSFrequencyType>(
 	"CSSFrequencyType",

--- a/packages/@romefrontend/ast/css/types/CSSGradientType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSGradientType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSGradientType = NodeBaseWithComments & {
+export interface CSSGradientType extends NodeBaseWithComments {
 	type: "CSSGradientType";
 	// TODO
-};
+}
 
 export const cssGradientType = createBuilder<CSSGradientType>(
 	"CSSGradientType",

--- a/packages/@romefrontend/ast/css/types/CSSIdentifierType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSIdentifierType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSIdentifierType = NodeBaseWithComments & {
+export interface CSSIdentifierType extends NodeBaseWithComments {
 	type: "CSSIdentifierType";
 	name: string;
-};
+}
 
 export const cssIdentifierType = createBuilder<CSSIdentifierType>(
 	"CSSIdentifierType",

--- a/packages/@romefrontend/ast/css/types/CSSImageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSImageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSImageType = NodeBaseWithComments & {
+export interface CSSImageType extends NodeBaseWithComments {
 	type: "CSSImageType";
 	// TODO
-};
+}
 
 export const cssImageType = createBuilder<CSSImageType>(
 	"CSSImageType",

--- a/packages/@romefrontend/ast/css/types/CSSIntegerType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSIntegerType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSIntegerType = NodeBaseWithComments & {
+export interface CSSIntegerType extends NodeBaseWithComments {
 	type: "CSSIntegerType";
 	// TODO
-};
+}
 
 export const cssIntegerType = createBuilder<CSSIntegerType>(
 	"CSSIntegerType",

--- a/packages/@romefrontend/ast/css/types/CSSLengthPercentageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSLengthPercentageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSLengthPercentageType = NodeBaseWithComments & {
+export interface CSSLengthPercentageType extends NodeBaseWithComments {
 	type: "CSSLengthPercentageType";
 	// TODO
-};
+}
 
 export const cssLengthPercentageType = createBuilder<CSSLengthPercentageType>(
 	"CSSLengthPercentageType",

--- a/packages/@romefrontend/ast/css/types/CSSLengthType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSLengthType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSLengthType = NodeBaseWithComments & {
+export interface CSSLengthType extends NodeBaseWithComments {
 	type: "CSSLengthType";
 	// TODO
-};
+}
 
 export const cssLengthType = createBuilder<CSSLengthType>(
 	"CSSLengthType",

--- a/packages/@romefrontend/ast/css/types/CSSNumberType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSNumberType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSNumberType = NodeBaseWithComments & {
+export interface CSSNumberType extends NodeBaseWithComments {
 	type: "CSSNumberType";
 	// TODO
-};
+}
 
 export const cssNumberType = createBuilder<CSSNumberType>(
 	"CSSNumberType",

--- a/packages/@romefrontend/ast/css/types/CSSPercentageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSPercentageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSPercentageType = NodeBaseWithComments & {
+export interface CSSPercentageType extends NodeBaseWithComments {
 	type: "CSSPercentageType";
 	value: number;
-};
+}
 
 export const cssPercentageType = createBuilder<CSSPercentageType>(
 	"CSSPercentageType",

--- a/packages/@romefrontend/ast/css/types/CSSRatioType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSRatioType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSRatioType = NodeBaseWithComments & {
+export interface CSSRatioType extends NodeBaseWithComments {
 	type: "CSSRatioType";
 	// TODO
-};
+}
 
 export const cssRatioType = createBuilder<CSSRatioType>(
 	"CSSRatioType",

--- a/packages/@romefrontend/ast/css/types/CSSResolutionType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSResolutionType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSResolutionType = NodeBaseWithComments & {
+export interface CSSResolutionType extends NodeBaseWithComments {
 	type: "CSSResolutionType";
 	// TODO
-};
+}
 
 export const cssResolutionType = createBuilder<CSSResolutionType>(
 	"CSSResolutionType",

--- a/packages/@romefrontend/ast/css/types/CSSShapeType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSShapeType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSShapeType = NodeBaseWithComments & {
+export interface CSSShapeType extends NodeBaseWithComments {
 	type: "CSSShapeType";
 	// TODO
-};
+}
 
 export const cssShapeType = createBuilder<CSSShapeType>(
 	"CSSShapeType",

--- a/packages/@romefrontend/ast/css/types/CSSStringType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSStringType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSStringType = NodeBaseWithComments & {
+export interface CSSStringType extends NodeBaseWithComments {
 	type: "CSSStringType";
 	value: string;
-};
+}
 
 export const cssStringType = createBuilder<CSSStringType>(
 	"CSSStringType",

--- a/packages/@romefrontend/ast/css/types/CSSTimePercentageType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSTimePercentageType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSTimePercentageType = NodeBaseWithComments & {
+export interface CSSTimePercentageType extends NodeBaseWithComments {
 	type: "CSSTimePercentageType";
 	// TODO
-};
+}
 
 export const cssTimePercentageType = createBuilder<CSSTimePercentageType>(
 	"CSSTimePercentageType",

--- a/packages/@romefrontend/ast/css/types/CSSTimeType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSTimeType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSTimeType = NodeBaseWithComments & {
+export interface CSSTimeType extends NodeBaseWithComments {
 	type: "CSSTimeType";
 	// TODO
-};
+}
 
 export const cssTimeType = createBuilder<CSSTimeType>(
 	"CSSTimeType",

--- a/packages/@romefrontend/ast/css/types/CSSTransformFunctionType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSTransformFunctionType.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSTransformFunctionType = NodeBaseWithComments & {
+export interface CSSTransformFunctionType extends NodeBaseWithComments {
 	type: "CSSTransformFunctionType";
 	// TODO
-};
+}
 
 export const cssTransformFunctionType = createBuilder<CSSTransformFunctionType>(
 	"CSSTransformFunctionType",

--- a/packages/@romefrontend/ast/css/types/CSSURLType.ts
+++ b/packages/@romefrontend/ast/css/types/CSSURLType.ts
@@ -1,10 +1,10 @@
 import {CSSStringType, NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type CSSURLType = NodeBaseWithComments & {
+export interface CSSURLType extends NodeBaseWithComments {
 	type: "CSSURLType";
 	url: CSSStringType;
-};
+}
 
 export const cssurlType = createBuilder<CSSURLType>(
 	"CSSURLType",

--- a/packages/@romefrontend/ast/html/attributes/HTMLAttribute.ts
+++ b/packages/@romefrontend/ast/html/attributes/HTMLAttribute.ts
@@ -6,11 +6,11 @@ import {
 import {createBuilder} from "../../utils";
 
 // class="something"
-export type HTMLAttribute = NodeBaseWithComments & {
+export interface HTMLAttribute extends NodeBaseWithComments {
 	type: "HTMLAttribute";
 	name: HTMLIdentifier;
 	value: HTMLString;
-};
+}
 
 export const htmlAttribute = createBuilder<HTMLAttribute>(
 	"HTMLAttribute",

--- a/packages/@romefrontend/ast/html/core/HTMLIdentifier.ts
+++ b/packages/@romefrontend/ast/html/core/HTMLIdentifier.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type HTMLIdentifier = NodeBaseWithComments & {
+export interface HTMLIdentifier extends NodeBaseWithComments {
 	type: "HTMLIdentifier";
 	name: string;
-};
+}
 
 export const htmlIdentifier = createBuilder<HTMLIdentifier>(
 	"HTMLIdentifier",

--- a/packages/@romefrontend/ast/html/core/HTMLRoot.ts
+++ b/packages/@romefrontend/ast/html/core/HTMLRoot.ts
@@ -2,11 +2,11 @@ import {NodeBaseWithComments, RootBase} from "../../index";
 import {createBuilder} from "../../utils";
 import {AnyHTMLChildNode} from "@romefrontend/ast/html/unions";
 
-export type HTMLRoot = NodeBaseWithComments &
-	RootBase & {
-		type: "HTMLRoot";
-		body: Array<AnyHTMLChildNode>;
-	};
+export interface HTMLRoot extends NodeBaseWithComments,
+RootBase {
+	type: "HTMLRoot";
+	body: Array<AnyHTMLChildNode>;
+}
 
 export const htmlRoot = createBuilder<HTMLRoot>(
 	"HTMLRoot",

--- a/packages/@romefrontend/ast/html/core/HTMLString.ts
+++ b/packages/@romefrontend/ast/html/core/HTMLString.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type HTMLString = NodeBaseWithComments & {
+export interface HTMLString extends NodeBaseWithComments {
 	type: "HTMLString";
 	value: string;
-};
+}
 
 export const htmlString = createBuilder<HTMLString>(
 	"HTMLString",

--- a/packages/@romefrontend/ast/html/core/HTMLText.ts
+++ b/packages/@romefrontend/ast/html/core/HTMLText.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "../../index";
 import {createBuilder} from "../../utils";
 
-export type HTMLText = NodeBaseWithComments & {
+export interface HTMLText extends NodeBaseWithComments {
 	type: "HTMLText";
 	value: string;
-};
+}
 
 export const htmlText = createBuilder<HTMLText>(
 	"HTMLText",

--- a/packages/@romefrontend/ast/html/tags/HTMLDoctypeTag.ts
+++ b/packages/@romefrontend/ast/html/tags/HTMLDoctypeTag.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type HTMLDoctypeTag = NodeBaseWithComments & {
+export interface HTMLDoctypeTag extends NodeBaseWithComments {
 	type: "HTMLDoctypeTag";
 	value: string;
-};
+}
 
 export const htmlDoctypeTag = createBuilder<HTMLDoctypeTag>(
 	"HTMLDoctypeTag",

--- a/packages/@romefrontend/ast/html/tags/HTMLElement.ts
+++ b/packages/@romefrontend/ast/html/tags/HTMLElement.ts
@@ -6,13 +6,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type HTMLElement = NodeBaseWithComments & {
+export interface HTMLElement extends NodeBaseWithComments {
 	type: "HTMLElement";
 	name: HTMLIdentifier;
 	selfClosing?: boolean;
 	attributes: Array<HTMLAttribute>;
 	children: Array<AnyHTMLChildNode>;
-};
+}
 
 export const htmlElement = createBuilder<HTMLElement>(
 	"HTMLElement",

--- a/packages/@romefrontend/ast/js/auxiliary/JSArrayHole.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSArrayHole.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSArrayHole = NodeBaseWithComments & {
+export interface JSArrayHole extends NodeBaseWithComments {
 	type: "JSArrayHole";
-};
+}
 
 export const jsArrayHole = createBuilder<JSArrayHole>(
 	"ArrayHole",

--- a/packages/@romefrontend/ast/js/auxiliary/JSCatchClause.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSCatchClause.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSCatchClause = NodeBaseWithComments & {
+export interface JSCatchClause extends NodeBaseWithComments {
 	type: "JSCatchClause";
 	param?: AnyJSBindingPattern;
 	body: JSBlockStatement;
-};
+}
 
 export const jsCatchClause = createBuilder<JSCatchClause>(
 	"JSCatchClause",

--- a/packages/@romefrontend/ast/js/auxiliary/JSComputedMemberProperty.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSComputedMemberProperty.ts
@@ -8,11 +8,11 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSComputedMemberProperty = NodeBaseWithComments & {
+export interface JSComputedMemberProperty extends NodeBaseWithComments {
 	type: "JSComputedMemberProperty";
 	value: AnyJSExpression;
 	optional?: boolean;
-};
+}
 
 export const jsComputedMemberProperty = createQuickBuilder<
 	JSComputedMemberProperty,

--- a/packages/@romefrontend/ast/js/auxiliary/JSFunctionHead.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSFunctionHead.ts
@@ -15,7 +15,7 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSFunctionHead = NodeBaseWithComments & {
+export interface JSFunctionHead extends NodeBaseWithComments {
 	type: "JSFunctionHead";
 	params: Array<AnyJSParamBindingPattern>;
 	rest?: AnyJSTargetBindingPattern;
@@ -25,7 +25,7 @@ export type JSFunctionHead = NodeBaseWithComments & {
 	async?: boolean;
 	typeParameters?: TSTypeParameterDeclaration;
 	returnType?: AnyTSPrimary;
-};
+}
 
 export const jsFunctionHead = createQuickBuilder<JSFunctionHead, "params">(
 	"JSFunctionHead",

--- a/packages/@romefrontend/ast/js/auxiliary/JSIdentifier.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSIdentifier.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSIdentifier = NodeBaseWithComments & {
+export interface JSIdentifier extends NodeBaseWithComments {
 	type: "JSIdentifier";
 	name: string;
 	definite?: boolean;
-};
+}
 
 export const jsIdentifier = createQuickBuilder<JSIdentifier, "name">(
 	"JSIdentifier",

--- a/packages/@romefrontend/ast/js/auxiliary/JSSpreadElement.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSSpreadElement.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSSpreadElement = NodeBaseWithComments & {
+export interface JSSpreadElement extends NodeBaseWithComments {
 	type: "JSSpreadElement";
 	argument: AnyJSExpression;
-};
+}
 
 export const jsSpreadElement = createQuickBuilder<JSSpreadElement, "argument">(
 	"JSSpreadElement",

--- a/packages/@romefrontend/ast/js/auxiliary/JSStaticMemberProperty.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSStaticMemberProperty.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSStaticMemberProperty = NodeBaseWithComments & {
+export interface JSStaticMemberProperty extends NodeBaseWithComments {
 	type: "JSStaticMemberProperty";
 	value: JSIdentifier | JSPrivateName;
 	optional?: boolean;
-};
+}
 
 export const jsStaticMemberProperty = createQuickBuilder<
 	JSStaticMemberProperty,

--- a/packages/@romefrontend/ast/js/auxiliary/JSSwitchCase.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSSwitchCase.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSSwitchCase = NodeBaseWithComments & {
+export interface JSSwitchCase extends NodeBaseWithComments {
 	type: "JSSwitchCase";
 	test?: AnyJSExpression;
 	consequent: Array<AnyJSStatement>;
-};
+}
 
 export const jsSwitchCase = createBuilder<JSSwitchCase>(
 	"JSSwitchCase",

--- a/packages/@romefrontend/ast/js/auxiliary/JSTemplateElement.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSTemplateElement.ts
@@ -8,12 +8,12 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSTemplateElement = NodeBaseWithComments & {
+export interface JSTemplateElement extends NodeBaseWithComments {
 	type: "JSTemplateElement";
 	tail?: boolean;
 	cooked: string;
 	raw: string;
-};
+}
 
 export const jsTemplateElement = createBuilder<JSTemplateElement>(
 	"JSTemplateElement",

--- a/packages/@romefrontend/ast/js/auxiliary/JSVariableDeclaration.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSVariableDeclaration.ts
@@ -10,11 +10,11 @@ import {createBuilder} from "../../utils";
 
 export type JSVariableDeclarationKind = "var" | "let" | "const";
 
-export type JSVariableDeclaration = NodeBaseWithComments & {
+export interface JSVariableDeclaration extends NodeBaseWithComments {
 	type: "JSVariableDeclaration";
 	kind: JSVariableDeclarationKind;
 	declarations: Array<JSVariableDeclarator>;
-};
+}
 
 export const jsVariableDeclaration = createBuilder<JSVariableDeclaration>(
 	"JSVariableDeclaration",

--- a/packages/@romefrontend/ast/js/auxiliary/JSVariableDeclarator.ts
+++ b/packages/@romefrontend/ast/js/auxiliary/JSVariableDeclarator.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSVariableDeclarator = NodeBaseWithComments & {
+export interface JSVariableDeclarator extends NodeBaseWithComments {
 	type: "JSVariableDeclarator";
 	id: AnyJSTargetBindingPattern;
 	init?: AnyJSExpression;
-};
+}
 
 export const jsVariableDeclarator = createBuilder<JSVariableDeclarator>(
 	"JSVariableDeclarator",

--- a/packages/@romefrontend/ast/js/classes/JSClassDeclaration.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassDeclaration.ts
@@ -12,13 +12,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassDeclaration = NodeBaseWithComments & {
+export interface JSClassDeclaration extends NodeBaseWithComments {
 	type: "JSClassDeclaration";
 	id: JSBindingIdentifier;
 	meta: JSClassHead;
 	abstract?: boolean;
 	declare?: boolean;
-};
+}
 
 export const jsClassDeclaration = createBuilder<JSClassDeclaration>(
 	"JSClassDeclaration",

--- a/packages/@romefrontend/ast/js/classes/JSClassExpression.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassExpression.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassExpression = NodeBaseWithComments & {
+export interface JSClassExpression extends NodeBaseWithComments {
 	type: "JSClassExpression";
 	id?: JSBindingIdentifier;
 	meta: JSClassHead;
-};
+}
 
 export const jsClassExpression = createBuilder<JSClassExpression>(
 	"JSClassExpression",

--- a/packages/@romefrontend/ast/js/classes/JSClassHead.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassHead.ts
@@ -15,14 +15,14 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSClassHead = NodeBaseWithComments & {
+export interface JSClassHead extends NodeBaseWithComments {
 	type: "JSClassHead";
 	superClass?: AnyJSExpression;
 	body: Array<AnyJSClassMember>;
 	typeParameters?: TSTypeParameterDeclaration;
 	superTypeParameters?: TSTypeParameterInstantiation;
 	implements?: undefined | Array<TSExpressionWithTypeArguments>;
-};
+}
 
 export const jsClassHead = createQuickBuilder<JSClassHead, "body">(
 	"JSClassHead",

--- a/packages/@romefrontend/ast/js/classes/JSClassMethod.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassMethod.ts
@@ -14,14 +14,14 @@ import {
 import {createBuilder} from "../../utils";
 import {AnyJSObjectPropertyKey} from "../unions";
 
-export type JSClassMethod = NodeBaseWithComments & {
+export interface JSClassMethod extends NodeBaseWithComments {
 	type: "JSClassMethod";
 	meta: JSClassPropertyMeta;
 	key: AnyJSObjectPropertyKey;
 	kind: JSClassMethodKind;
 	head: JSFunctionHead;
 	body: JSBlockStatement;
-};
+}
 
 export type JSClassMethodKind = "constructor" | "method" | "get" | "set";
 

--- a/packages/@romefrontend/ast/js/classes/JSClassPrivateMethod.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassPrivateMethod.ts
@@ -15,14 +15,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassPrivateMethod = NodeBaseWithComments & {
+export interface JSClassPrivateMethod extends NodeBaseWithComments {
 	type: "JSClassPrivateMethod";
 	kind: JSClassMethodKind;
 	key: JSPrivateName;
 	head: JSFunctionHead;
 	body: JSBlockStatement;
 	meta: JSClassPropertyMeta;
-};
+}
 
 export const jsClassPrivateMethod = createBuilder<JSClassPrivateMethod>(
 	"JSClassPrivateMethod",

--- a/packages/@romefrontend/ast/js/classes/JSClassPrivateProperty.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassPrivateProperty.ts
@@ -14,13 +14,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassPrivateProperty = NodeBaseWithComments & {
+export interface JSClassPrivateProperty extends NodeBaseWithComments {
 	type: "JSClassPrivateProperty";
 	key: JSPrivateName;
 	meta: JSClassPropertyMeta;
 	value: undefined | AnyJSExpression;
 	typeAnnotation?: AnyTSPrimary;
-};
+}
 
 export const jsClassPrivateProperty = createBuilder<JSClassPrivateProperty>(
 	"JSClassPrivateProperty",

--- a/packages/@romefrontend/ast/js/classes/JSClassProperty.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassProperty.ts
@@ -14,14 +14,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassProperty = NodeBaseWithComments & {
+export interface JSClassProperty extends NodeBaseWithComments {
 	type: "JSClassProperty";
 	key: AnyJSObjectPropertyKey;
 	meta: JSClassPropertyMeta;
 	value?: AnyJSExpression;
 	typeAnnotation?: AnyTSPrimary;
 	definite?: boolean;
-};
+}
 
 export const jsClassProperty = createBuilder<JSClassProperty>(
 	"JSClassProperty",

--- a/packages/@romefrontend/ast/js/classes/JSClassPropertyMeta.ts
+++ b/packages/@romefrontend/ast/js/classes/JSClassPropertyMeta.ts
@@ -8,14 +8,14 @@
 import {ConstTSAccessibility, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSClassPropertyMeta = NodeBaseWithComments & {
+export interface JSClassPropertyMeta extends NodeBaseWithComments {
 	type: "JSClassPropertyMeta";
 	static?: boolean;
 	accessibility?: ConstTSAccessibility;
 	optional?: boolean;
 	readonly?: boolean;
 	abstract?: boolean;
-};
+}
 
 export const jsClassPropertyMeta = createBuilder<JSClassPropertyMeta>(
 	"JSClassPropertyMeta",

--- a/packages/@romefrontend/ast/js/classes/JSPrivateName.ts
+++ b/packages/@romefrontend/ast/js/classes/JSPrivateName.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSPrivateName = NodeBaseWithComments & {
+export interface JSPrivateName extends NodeBaseWithComments {
 	type: "JSPrivateName";
 	id: JSIdentifier;
-};
+}
 
 export const jsPrivateName = createBuilder<JSPrivateName>(
 	"JSPrivateName",

--- a/packages/@romefrontend/ast/js/core/JSDirective.ts
+++ b/packages/@romefrontend/ast/js/core/JSDirective.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSDirective = NodeBaseWithComments & {
+export interface JSDirective extends NodeBaseWithComments {
 	type: "JSDirective";
 	value: string;
-};
+}
 
 export const jsDirective = createBuilder<JSDirective>(
 	"JSDirective",

--- a/packages/@romefrontend/ast/js/core/JSInterpreterDirective.ts
+++ b/packages/@romefrontend/ast/js/core/JSInterpreterDirective.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSInterpreterDirective = NodeBaseWithComments & {
+export interface JSInterpreterDirective extends NodeBaseWithComments {
 	type: "JSInterpreterDirective";
 	value: string;
-};
+}
 
 export const jsInterpreterDirective = createBuilder<JSInterpreterDirective>(
 	"JSInterpreterDirective",

--- a/packages/@romefrontend/ast/js/core/JSRoot.ts
+++ b/packages/@romefrontend/ast/js/core/JSRoot.ts
@@ -16,16 +16,16 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRoot = NodeBaseWithComments &
-	RootBase & {
-		type: "JSRoot";
-		directives: Array<JSDirective>;
-		body: Array<AnyJSStatement>;
-		interpreter: undefined | JSInterpreterDirective;
-		sourceType: ConstJSSourceType;
-		syntax: Array<ConstJSProgramSyntax>;
-		hasHoistedVars: boolean;
-	};
+export interface JSRoot extends NodeBaseWithComments,
+RootBase {
+	type: "JSRoot";
+	directives: Array<JSDirective>;
+	body: Array<AnyJSStatement>;
+	interpreter: undefined | JSInterpreterDirective;
+	sourceType: ConstJSSourceType;
+	syntax: Array<ConstJSProgramSyntax>;
+	hasHoistedVars: boolean;
+}
 
 export const MOCK_PROGRAM: JSRoot = {
 	type: "JSRoot",

--- a/packages/@romefrontend/ast/js/expressions/JSArrayExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSArrayExpression.ts
@@ -13,10 +13,10 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSArrayExpression = NodeBaseWithComments & {
+export interface JSArrayExpression extends NodeBaseWithComments {
 	type: "JSArrayExpression";
 	elements: Array<JSArrayHole | AnyJSExpression | JSSpreadElement>;
-};
+}
 
 export const jsArrayExpression = createQuickBuilder<
 	JSArrayExpression,

--- a/packages/@romefrontend/ast/js/expressions/JSArrowFunctionExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSArrowFunctionExpression.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSArrowFunctionExpression = NodeBaseWithComments & {
+export interface JSArrowFunctionExpression extends NodeBaseWithComments {
 	type: "JSArrowFunctionExpression";
 	head: JSFunctionHead;
 	body: JSBlockStatement | AnyJSExpression;
 	generator?: void;
-};
+}
 
 export const jsArrowFunctionExpression = createBuilder<JSArrowFunctionExpression>(
 	"JSArrowFunctionExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSAssignmentExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSAssignmentExpression.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAssignmentExpression = NodeBaseWithComments & {
+export interface JSAssignmentExpression extends NodeBaseWithComments {
 	type: "JSAssignmentExpression";
 	operator: AssignmentOperator;
 	left: AnyJSAssignmentPattern;
 	right: AnyJSExpression;
-};
+}
 
 export type AssignmentOperator =
 	| "="

--- a/packages/@romefrontend/ast/js/expressions/JSAwaitExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSAwaitExpression.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAwaitExpression = NodeBaseWithComments & {
+export interface JSAwaitExpression extends NodeBaseWithComments {
 	type: "JSAwaitExpression";
 	argument?: AnyJSExpression;
-};
+}
 
 export const jsAwaitExpression = createBuilder<JSAwaitExpression>(
 	"JSAwaitExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSBinaryExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSBinaryExpression.ts
@@ -8,12 +8,12 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBinaryExpression = NodeBaseWithComments & {
+export interface JSBinaryExpression extends NodeBaseWithComments {
 	type: "JSBinaryExpression";
 	operator: BinaryOperator;
 	left: AnyJSExpression;
 	right: AnyJSExpression;
-};
+}
 
 export type BinaryOperator =
 	| "=="

--- a/packages/@romefrontend/ast/js/expressions/JSCallExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSCallExpression.ts
@@ -14,12 +14,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSCallExpression = NodeBaseWithComments & {
+export interface JSCallExpression extends NodeBaseWithComments {
 	type: "JSCallExpression";
 	callee: AnyJSExpression | JSSuper;
 	arguments: Array<AnyJSExpression | JSSpreadElement>;
 	typeArguments?: TSTypeParameterInstantiation;
-};
+}
 
 export const jsCallExpression = createBuilder<JSCallExpression>(
 	"JSCallExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSConditionalExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSConditionalExpression.ts
@@ -8,12 +8,12 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSConditionalExpression = NodeBaseWithComments & {
+export interface JSConditionalExpression extends NodeBaseWithComments {
 	type: "JSConditionalExpression";
 	test: AnyJSExpression;
 	alternate: AnyJSExpression;
 	consequent: AnyJSExpression;
-};
+}
 
 export const jsConditionalExpression = createBuilder<JSConditionalExpression>(
 	"JSConditionalExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSDoExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSDoExpression.ts
@@ -8,10 +8,10 @@
 import {JSBlockStatement, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSDoExpression = NodeBaseWithComments & {
+export interface JSDoExpression extends NodeBaseWithComments {
 	type: "JSDoExpression";
 	body: JSBlockStatement;
-};
+}
 
 export const jsDoExpression = createBuilder<JSDoExpression>(
 	"JSDoExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSFunctionExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSFunctionExpression.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSFunctionExpression = NodeBaseWithComments & {
+export interface JSFunctionExpression extends NodeBaseWithComments {
 	type: "JSFunctionExpression";
 	id?: JSBindingIdentifier;
 	head: JSFunctionHead;
 	body: JSBlockStatement;
-};
+}
 
 export const jsFunctionExpression = createBuilder<JSFunctionExpression>(
 	"JSFunctionExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSLogicalExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSLogicalExpression.ts
@@ -8,12 +8,12 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSLogicalExpression = NodeBaseWithComments & {
+export interface JSLogicalExpression extends NodeBaseWithComments {
 	type: "JSLogicalExpression";
 	operator: LogicalOperator;
 	left: AnyJSExpression;
 	right: AnyJSExpression;
-};
+}
 
 export type LogicalOperator = "||" | "&&" | "??";
 

--- a/packages/@romefrontend/ast/js/expressions/JSMemberExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSMemberExpression.ts
@@ -14,11 +14,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSMemberExpression = NodeBaseWithComments & {
+export interface JSMemberExpression extends NodeBaseWithComments {
 	type: "JSMemberExpression";
 	object: AnyJSExpression | JSSuper;
 	property: JSStaticMemberProperty | JSComputedMemberProperty;
-};
+}
 
 export const jsMemberExpression = createBuilder<JSMemberExpression>(
 	"JSMemberExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSMetaProperty.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSMetaProperty.ts
@@ -8,11 +8,11 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSMetaProperty = NodeBaseWithComments & {
+export interface JSMetaProperty extends NodeBaseWithComments {
 	type: "JSMetaProperty";
 	meta: JSIdentifier;
 	property: JSIdentifier;
-};
+}
 
 export const jsMetaProperty = createBuilder<JSMetaProperty>(
 	"JSMetaProperty",

--- a/packages/@romefrontend/ast/js/expressions/JSNewExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSNewExpression.ts
@@ -14,13 +14,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSNewExpression = NodeBaseWithComments & {
+export interface JSNewExpression extends NodeBaseWithComments {
 	type: "JSNewExpression";
 	callee: AnyJSExpression | JSSuper;
 	arguments: Array<AnyJSExpression | JSSpreadElement>;
 	typeArguments?: undefined | TSTypeParameterInstantiation;
 	optional?: boolean;
-};
+}
 
 export const jsNewExpression = createBuilder<JSNewExpression>(
 	"JSNewExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSOptionalCallExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSOptionalCallExpression.ts
@@ -14,12 +14,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSOptionalCallExpression = NodeBaseWithComments & {
+export interface JSOptionalCallExpression extends NodeBaseWithComments {
 	type: "JSOptionalCallExpression";
 	callee: AnyJSExpression | JSSuper;
 	arguments: Array<AnyJSExpression | JSSpreadElement>;
 	typeArguments?: TSTypeParameterInstantiation;
-};
+}
 
 export const jsOptionalCallExpression = createBuilder<JSOptionalCallExpression>(
 	"JSOptionalCallExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSReferenceIdentifier.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSReferenceIdentifier.ts
@@ -8,12 +8,12 @@
 import {JSPatternMeta, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSReferenceIdentifier = NodeBaseWithComments & {
+export interface JSReferenceIdentifier extends NodeBaseWithComments {
 	type: "JSReferenceIdentifier";
 	name: string;
 	definite?: boolean;
 	meta?: JSPatternMeta;
-};
+}
 
 export const jsReferenceIdentifier = createQuickBuilder<
 	JSReferenceIdentifier,

--- a/packages/@romefrontend/ast/js/expressions/JSSequenceExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSSequenceExpression.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSSequenceExpression = NodeBaseWithComments & {
+export interface JSSequenceExpression extends NodeBaseWithComments {
 	type: "JSSequenceExpression";
 	expressions: Array<AnyJSExpression>;
-};
+}
 
 export const jsSequenceExpression = createBuilder<JSSequenceExpression>(
 	"JSSequenceExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSSuper.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSSuper.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSSuper = NodeBaseWithComments & {
+export interface JSSuper extends NodeBaseWithComments {
 	type: "JSSuper";
-};
+}
 
 export const jsSuper = createBuilder<JSSuper>(
 	"JSSuper",

--- a/packages/@romefrontend/ast/js/expressions/JSTaggedTemplateExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSTaggedTemplateExpression.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSTaggedTemplateExpression = NodeBaseWithComments & {
+export interface JSTaggedTemplateExpression extends NodeBaseWithComments {
 	type: "JSTaggedTemplateExpression";
 	tag: AnyJSExpression;
 	quasi: JSTemplateLiteral;
 	typeArguments?: TSTypeParameterInstantiation;
-};
+}
 
 export const jsTaggedTemplateExpression = createBuilder<JSTaggedTemplateExpression>(
 	"JSTaggedTemplateExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSThisExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSThisExpression.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSThisExpression = NodeBaseWithComments & {
+export interface JSThisExpression extends NodeBaseWithComments {
 	type: "JSThisExpression";
-};
+}
 
 export const jsThisExpression = createBuilder<JSThisExpression>(
 	"JSThisExpression",

--- a/packages/@romefrontend/ast/js/expressions/JSUnaryExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSUnaryExpression.ts
@@ -8,12 +8,12 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSUnaryExpression = NodeBaseWithComments & {
+export interface JSUnaryExpression extends NodeBaseWithComments {
 	type: "JSUnaryExpression";
 	operator: UnaryOperator;
 	prefix?: boolean;
 	argument: AnyJSExpression;
-};
+}
 
 export type UnaryOperator =
 	| "-"

--- a/packages/@romefrontend/ast/js/expressions/JSUpdateExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSUpdateExpression.ts
@@ -8,12 +8,12 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSUpdateExpression = NodeBaseWithComments & {
+export interface JSUpdateExpression extends NodeBaseWithComments {
 	type: "JSUpdateExpression";
 	operator: UpdateOperator;
 	argument: AnyJSExpression;
 	prefix?: boolean;
-};
+}
 
 export type UpdateOperator = "++" | "--";
 

--- a/packages/@romefrontend/ast/js/expressions/JSYieldExpression.ts
+++ b/packages/@romefrontend/ast/js/expressions/JSYieldExpression.ts
@@ -8,11 +8,11 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSYieldExpression = NodeBaseWithComments & {
+export interface JSYieldExpression extends NodeBaseWithComments {
 	type: "JSYieldExpression";
 	delegate?: boolean;
 	argument?: AnyJSExpression;
-};
+}
 
 export const jsYieldExpression = createBuilder<JSYieldExpression>(
 	"JSYieldExpression",

--- a/packages/@romefrontend/ast/js/jsx/JSXAttribute.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXAttribute.ts
@@ -16,7 +16,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXAttribute = NodeBaseWithComments & {
+export interface JSXAttribute extends NodeBaseWithComments {
 	type: "JSXAttribute";
 	name: JSXIdentifier | JSXNamespacedName;
 	value?:
@@ -25,7 +25,7 @@ export type JSXAttribute = NodeBaseWithComments & {
 		| JSXFragment
 		| JSStringLiteral
 		| JSXExpressionContainer;
-};
+}
 
 export const jsxAttribute = createBuilder<JSXAttribute>(
 	"JSXAttribute",

--- a/packages/@romefrontend/ast/js/jsx/JSXElement.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXElement.ts
@@ -21,7 +21,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXElement = NodeBaseWithComments & {
+export interface JSXElement extends NodeBaseWithComments {
 	type: "JSXElement";
 	name:
 		| JSXReferenceIdentifier
@@ -34,7 +34,7 @@ export type JSXElement = NodeBaseWithComments & {
 	children: Array<
 		JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment
 	>;
-};
+}
 
 export const jsxElement = createBuilder<JSXElement>(
 	"JSXElement",

--- a/packages/@romefrontend/ast/js/jsx/JSXEmptyExpression.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXEmptyExpression.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXEmptyExpression = NodeBaseWithComments & {
+export interface JSXEmptyExpression extends NodeBaseWithComments {
 	type: "JSXEmptyExpression";
-};
+}
 
 export const jsxEmptyExpression = createBuilder<JSXEmptyExpression>(
 	"JSXEmptyExpression",

--- a/packages/@romefrontend/ast/js/jsx/JSXExpressionContainer.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXExpressionContainer.ts
@@ -12,10 +12,10 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXExpressionContainer = NodeBaseWithComments & {
+export interface JSXExpressionContainer extends NodeBaseWithComments {
 	type: "JSXExpressionContainer";
 	expression: AnyJSExpression | JSXEmptyExpression;
-};
+}
 
 export const jsxExpressionContainer = createBuilder<JSXExpressionContainer>(
 	"JSXExpressionContainer",

--- a/packages/@romefrontend/ast/js/jsx/JSXFragment.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXFragment.ts
@@ -8,10 +8,10 @@
 import {JSXElement, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXFragment = NodeBaseWithComments & {
+export interface JSXFragment extends NodeBaseWithComments {
 	type: "JSXFragment";
 	children: JSXElement["children"];
-};
+}
 
 export const jsxFragment = createBuilder<JSXFragment>(
 	"JSXFragment",

--- a/packages/@romefrontend/ast/js/jsx/JSXIdentifier.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXIdentifier.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSXIdentifier = NodeBaseWithComments & {
+export interface JSXIdentifier extends NodeBaseWithComments {
 	type: "JSXIdentifier";
 	name: string;
-};
+}
 
 export const jsxIdentifier = createQuickBuilder<JSXIdentifier, "name">(
 	"JSXIdentifier",

--- a/packages/@romefrontend/ast/js/jsx/JSXMemberExpression.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXMemberExpression.ts
@@ -13,7 +13,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXMemberExpression = NodeBaseWithComments & {
+export interface JSXMemberExpression extends NodeBaseWithComments {
 	type: "JSXMemberExpression";
 	object:
 		| JSXMemberExpression
@@ -21,7 +21,7 @@ export type JSXMemberExpression = NodeBaseWithComments & {
 		| JSXReferenceIdentifier
 		| JSXNamespacedName;
 	property: JSXIdentifier;
-};
+}
 
 export const jsxMemberExpression = createBuilder<JSXMemberExpression>(
 	"JSXMemberExpression",

--- a/packages/@romefrontend/ast/js/jsx/JSXNamespacedName.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXNamespacedName.ts
@@ -8,11 +8,11 @@
 import {JSXIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXNamespacedName = NodeBaseWithComments & {
+export interface JSXNamespacedName extends NodeBaseWithComments {
 	type: "JSXNamespacedName";
 	namespace: JSXIdentifier;
 	name: JSXIdentifier;
-};
+}
 
 export const jsxNamespacedName = createBuilder<JSXNamespacedName>(
 	"JSXNamespacedName",

--- a/packages/@romefrontend/ast/js/jsx/JSXReferenceIdentifier.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXReferenceIdentifier.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXReferenceIdentifier = NodeBaseWithComments & {
+export interface JSXReferenceIdentifier extends NodeBaseWithComments {
 	type: "JSXReferenceIdentifier";
 	name: string;
-};
+}
 
 export const jsxReferenceIdentifier = createBuilder<JSXReferenceIdentifier>(
 	"JSXReferenceIdentifier",

--- a/packages/@romefrontend/ast/js/jsx/JSXSpreadAttribute.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXSpreadAttribute.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXSpreadAttribute = NodeBaseWithComments & {
+export interface JSXSpreadAttribute extends NodeBaseWithComments {
 	type: "JSXSpreadAttribute";
 	argument: AnyJSExpression;
-};
+}
 
 export const jsxSpreadAttribute = createBuilder<JSXSpreadAttribute>(
 	"JSXSpreadAttribute",

--- a/packages/@romefrontend/ast/js/jsx/JSXSpreadChild.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXSpreadChild.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXSpreadChild = NodeBaseWithComments & {
+export interface JSXSpreadChild extends NodeBaseWithComments {
 	type: "JSXSpreadChild";
 	expression: AnyJSExpression;
-};
+}
 
 export const jsxSpreadChild = createBuilder<JSXSpreadChild>(
 	"JSXSpreadChild",

--- a/packages/@romefrontend/ast/js/jsx/JSXText.ts
+++ b/packages/@romefrontend/ast/js/jsx/JSXText.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSXText = NodeBaseWithComments & {
+export interface JSXText extends NodeBaseWithComments {
 	type: "JSXText";
 	value: string;
-};
+}
 
 export const jsxText = createBuilder<JSXText>(
 	"JSXText",

--- a/packages/@romefrontend/ast/js/literals/JSBigIntLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSBigIntLiteral.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBigIntLiteral = NodeBaseWithComments & {
+export interface JSBigIntLiteral extends NodeBaseWithComments {
 	type: "JSBigIntLiteral";
 	value: string;
-};
+}
 
 export const jsBigIntLiteral = createBuilder<JSBigIntLiteral>(
 	"JSBigIntLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSBooleanLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSBooleanLiteral.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSBooleanLiteral = NodeBaseWithComments & {
+export interface JSBooleanLiteral extends NodeBaseWithComments {
 	type: "JSBooleanLiteral";
 	value: boolean;
-};
+}
 
 export const jsBooleanLiteral = createQuickBuilder<JSBooleanLiteral, "value">(
 	"JSBooleanLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSNullLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSNullLiteral.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSNullLiteral = NodeBaseWithComments & {
+export interface JSNullLiteral extends NodeBaseWithComments {
 	type: "JSNullLiteral";
-};
+}
 
 export const jsNullLiteral = createBuilder<JSNullLiteral>(
 	"JSNullLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSNumericLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSNumericLiteral.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSNumericLiteral = NodeBaseWithComments & {
+export interface JSNumericLiteral extends NodeBaseWithComments {
 	type: "JSNumericLiteral";
 	value: number;
 	format?: "octal" | "binary" | "hex";
-};
+}
 
 export const jsNumericLiteral = createQuickBuilder<JSNumericLiteral, "value">(
 	"JSNumericLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSRegExpLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSRegExpLiteral.ts
@@ -12,7 +12,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpLiteral = NodeBaseWithComments & {
+export interface JSRegExpLiteral extends NodeBaseWithComments {
 	type: "JSRegExpLiteral";
 	expression: JSRegExpSubExpression | JSRegExpAlternation;
 	global?: boolean;
@@ -21,7 +21,7 @@ export type JSRegExpLiteral = NodeBaseWithComments & {
 	insensitive?: boolean;
 	noDotNewline?: boolean;
 	unicode?: boolean;
-};
+}
 
 export const jsRegExpLiteral = createBuilder<JSRegExpLiteral>(
 	"JSRegExpLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSStringLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSStringLiteral.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSStringLiteral = NodeBaseWithComments & {
+export interface JSStringLiteral extends NodeBaseWithComments {
 	type: "JSStringLiteral";
 	value: string;
-};
+}
 
 export const jsStringLiteral = createQuickBuilder<JSStringLiteral, "value">(
 	"JSStringLiteral",

--- a/packages/@romefrontend/ast/js/literals/JSTemplateLiteral.ts
+++ b/packages/@romefrontend/ast/js/literals/JSTemplateLiteral.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSTemplateLiteral = NodeBaseWithComments & {
+export interface JSTemplateLiteral extends NodeBaseWithComments {
 	type: "JSTemplateLiteral";
 	quasis: Array<JSTemplateElement>;
 	expressions: Array<AnyJSExpression>;
-};
+}
 
 export const jsTemplateLiteral = createBuilder<JSTemplateLiteral>(
 	"JSTemplateLiteral",

--- a/packages/@romefrontend/ast/js/modules/JSExportAllDeclaration.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportAllDeclaration.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportAllDeclaration = NodeBaseWithComments & {
+export interface JSExportAllDeclaration extends NodeBaseWithComments {
 	type: "JSExportAllDeclaration";
 	source: JSStringLiteral;
 	exportKind?: ConstJSExportModuleKind;
 	declare?: boolean;
-};
+}
 
 export const jsExportAllDeclaration = createBuilder<JSExportAllDeclaration>(
 	"JSExportAllDeclaration",

--- a/packages/@romefrontend/ast/js/modules/JSExportDefaultDeclaration.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportDefaultDeclaration.ts
@@ -15,7 +15,7 @@ import {
 import {createBuilder} from "../../utils";
 import {TSDeclareFunction} from "../typescript/TSDeclareFunction";
 
-export type JSExportDefaultDeclaration = NodeBaseWithComments & {
+export interface JSExportDefaultDeclaration extends NodeBaseWithComments {
 	type: "JSExportDefaultDeclaration";
 	declaration:
 		| JSFunctionDeclaration
@@ -25,7 +25,7 @@ export type JSExportDefaultDeclaration = NodeBaseWithComments & {
 		| AnyJSExpression;
 	exportKind?: undefined;
 	declare?: boolean;
-};
+}
 
 export const jsExportDefaultDeclaration = createBuilder<JSExportDefaultDeclaration>(
 	"JSExportDefaultDeclaration",

--- a/packages/@romefrontend/ast/js/modules/JSExportDefaultSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportDefaultSpecifier.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportDefaultSpecifier = NodeBaseWithComments & {
+export interface JSExportDefaultSpecifier extends NodeBaseWithComments {
 	type: "JSExportDefaultSpecifier";
 	exported: JSIdentifier;
-};
+}
 
 export const jsExportDefaultSpecifier = createBuilder<JSExportDefaultSpecifier>(
 	"JSExportDefaultSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSExportExternalDeclaration.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportExternalDeclaration.ts
@@ -20,14 +20,14 @@ export type AnyExportExternalSpecifier =
 	| JSExportDefaultSpecifier
 	| JSExportExternalSpecifier;
 
-export type JSExportExternalDeclaration = NodeBaseWithComments & {
+export interface JSExportExternalDeclaration extends NodeBaseWithComments {
 	type: "JSExportExternalDeclaration";
 	defaultSpecifier?: JSExportDefaultSpecifier;
 	namespaceSpecifier?: JSExportNamespaceSpecifier;
 	namedSpecifiers: Array<JSExportExternalSpecifier>;
 	source: JSStringLiteral;
 	exportKind?: ConstJSExportModuleKind;
-};
+}
 
 export const jsExportExternalDeclaration = createBuilder<JSExportExternalDeclaration>(
 	"JSExportExternalDeclaration",

--- a/packages/@romefrontend/ast/js/modules/JSExportExternalSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportExternalSpecifier.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportExternalSpecifier = NodeBaseWithComments & {
+export interface JSExportExternalSpecifier extends NodeBaseWithComments {
 	type: "JSExportExternalSpecifier";
 	exported: JSIdentifier;
 	local: JSIdentifier;
 	exportKind?: ConstJSExportModuleKind;
-};
+}
 
 export const jsExportExternalSpecifier = createBuilder<JSExportExternalSpecifier>(
 	"JSExportExternalSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSExportLocalDeclaration.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportLocalDeclaration.ts
@@ -20,7 +20,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportLocalDeclaration = NodeBaseWithComments & {
+export interface JSExportLocalDeclaration extends NodeBaseWithComments {
 	type: "JSExportLocalDeclaration";
 	declaration?:
 		| undefined
@@ -35,7 +35,7 @@ export type JSExportLocalDeclaration = NodeBaseWithComments & {
 	specifiers?: Array<JSExportLocalSpecifier>;
 	exportKind?: ConstJSExportModuleKind;
 	declare?: boolean;
-};
+}
 
 export const jsExportLocalDeclaration = createBuilder<JSExportLocalDeclaration>(
 	"JSExportLocalDeclaration",

--- a/packages/@romefrontend/ast/js/modules/JSExportLocalSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportLocalSpecifier.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportLocalSpecifier = NodeBaseWithComments & {
+export interface JSExportLocalSpecifier extends NodeBaseWithComments {
 	type: "JSExportLocalSpecifier";
 	exported: JSIdentifier;
 	local: JSReferenceIdentifier;
 	exportKind?: ConstJSExportModuleKind;
-};
+}
 
 export const jsExportLocalSpecifier = createBuilder<JSExportLocalSpecifier>(
 	"JSExportLocalSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSExportNamespaceSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSExportNamespaceSpecifier.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExportNamespaceSpecifier = NodeBaseWithComments & {
+export interface JSExportNamespaceSpecifier extends NodeBaseWithComments {
 	type: "JSExportNamespaceSpecifier";
 	exported: JSIdentifier;
-};
+}
 
 export const jsExportNamespaceSpecifier = createBuilder<JSExportNamespaceSpecifier>(
 	"JSExportNamespaceSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSImportCall.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportCall.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSImportCall = NodeBaseWithComments & {
+export interface JSImportCall extends NodeBaseWithComments {
 	type: "JSImportCall";
 	argument: AnyJSExpression;
-};
+}
 
 export const jsImportCall = createBuilder<JSImportCall>(
 	"JSImportCall",

--- a/packages/@romefrontend/ast/js/modules/JSImportDeclaration.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportDeclaration.ts
@@ -20,14 +20,14 @@ export type AnyImportSpecifier =
 	| JSImportNamespaceSpecifier
 	| JSImportSpecifier;
 
-export type JSImportDeclaration = NodeBaseWithComments & {
+export interface JSImportDeclaration extends NodeBaseWithComments {
 	type: "JSImportDeclaration";
 	defaultSpecifier?: JSImportDefaultSpecifier;
 	namespaceSpecifier?: JSImportNamespaceSpecifier;
 	namedSpecifiers: Array<JSImportSpecifier>;
 	source: JSStringLiteral;
 	importKind?: ConstJSImportModuleKind;
-};
+}
 
 export const jsImportDeclaration = createBuilder<JSImportDeclaration>(
 	"JSImportDeclaration",

--- a/packages/@romefrontend/ast/js/modules/JSImportDefaultSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportDefaultSpecifier.ts
@@ -8,10 +8,10 @@
 import {JSImportSpecifierLocal, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSImportDefaultSpecifier = NodeBaseWithComments & {
+export interface JSImportDefaultSpecifier extends NodeBaseWithComments {
 	type: "JSImportDefaultSpecifier";
 	local: JSImportSpecifierLocal;
-};
+}
 
 export const jsImportDefaultSpecifier = createBuilder<JSImportDefaultSpecifier>(
 	"JSImportDefaultSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSImportNamespaceSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportNamespaceSpecifier.ts
@@ -8,10 +8,10 @@
 import {JSImportSpecifierLocal, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSImportNamespaceSpecifier = NodeBaseWithComments & {
+export interface JSImportNamespaceSpecifier extends NodeBaseWithComments {
 	type: "JSImportNamespaceSpecifier";
 	local: JSImportSpecifierLocal;
-};
+}
 
 export const jsImportNamespaceSpecifier = createBuilder<JSImportNamespaceSpecifier>(
 	"JSImportNamespaceSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSImportSpecifier.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportSpecifier.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSImportSpecifier = NodeBaseWithComments & {
+export interface JSImportSpecifier extends NodeBaseWithComments {
 	type: "JSImportSpecifier";
 	imported: JSIdentifier;
 	local: JSImportSpecifierLocal;
-};
+}
 
 export const jsImportSpecifier = createBuilder<JSImportSpecifier>(
 	"JSImportSpecifier",

--- a/packages/@romefrontend/ast/js/modules/JSImportSpecifierLocal.ts
+++ b/packages/@romefrontend/ast/js/modules/JSImportSpecifierLocal.ts
@@ -8,10 +8,10 @@
 import {JSBindingIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSImportSpecifierLocal = NodeBaseWithComments & {
+export interface JSImportSpecifierLocal extends NodeBaseWithComments {
 	type: "JSImportSpecifierLocal";
 	name: JSBindingIdentifier;
-};
+}
 
 export const jsImportSpecifierLocal = createQuickBuilder<
 	JSImportSpecifierLocal,

--- a/packages/@romefrontend/ast/js/objects/JSComputedPropertyKey.ts
+++ b/packages/@romefrontend/ast/js/objects/JSComputedPropertyKey.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSComputedPropertyKey = NodeBaseWithComments & {
+export interface JSComputedPropertyKey extends NodeBaseWithComments {
 	type: "JSComputedPropertyKey";
 	value: AnyJSExpression;
-};
+}
 
 export const jsComputedPropertyKey = createQuickBuilder<
 	JSComputedPropertyKey,

--- a/packages/@romefrontend/ast/js/objects/JSObjectExpression.ts
+++ b/packages/@romefrontend/ast/js/objects/JSObjectExpression.ts
@@ -8,10 +8,10 @@
 import {JSObjectProperties, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSObjectExpression = NodeBaseWithComments & {
+export interface JSObjectExpression extends NodeBaseWithComments {
 	type: "JSObjectExpression";
 	properties: JSObjectProperties;
-};
+}
 
 export const jsObjectExpression = createQuickBuilder<
 	JSObjectExpression,

--- a/packages/@romefrontend/ast/js/objects/JSObjectMethod.ts
+++ b/packages/@romefrontend/ast/js/objects/JSObjectMethod.ts
@@ -16,13 +16,13 @@ import {createBuilder} from "../../utils";
 
 export type JSObjectMethodKind = "get" | "set" | "method";
 
-export type JSObjectMethod = NodeBaseWithComments & {
+export interface JSObjectMethod extends NodeBaseWithComments {
 	key: JSComputedPropertyKey | JSStaticPropertyKey;
 	type: "JSObjectMethod";
 	kind: JSObjectMethodKind;
 	head: JSFunctionHead;
 	body: JSBlockStatement;
-};
+}
 
 export const jsObjectMethod = createBuilder<JSObjectMethod>(
 	"JSObjectMethod",

--- a/packages/@romefrontend/ast/js/objects/JSObjectProperty.ts
+++ b/packages/@romefrontend/ast/js/objects/JSObjectProperty.ts
@@ -13,11 +13,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSObjectProperty = NodeBaseWithComments & {
+export interface JSObjectProperty extends NodeBaseWithComments {
 	type: "JSObjectProperty";
 	key: JSStaticPropertyKey | JSComputedPropertyKey;
 	value: AnyJSExpression;
-};
+}
 
 export const jsObjectProperty = createBuilder<JSObjectProperty>(
 	"JSObjectProperty",

--- a/packages/@romefrontend/ast/js/objects/JSSpreadProperty.ts
+++ b/packages/@romefrontend/ast/js/objects/JSSpreadProperty.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSSpreadProperty = NodeBaseWithComments & {
+export interface JSSpreadProperty extends NodeBaseWithComments {
 	type: "JSSpreadProperty";
 	argument: AnyJSExpression;
-};
+}
 
 export const jsSpreadProperty = createBuilder<JSSpreadProperty>(
 	"JSSpreadProperty",

--- a/packages/@romefrontend/ast/js/objects/JSStaticPropertyKey.ts
+++ b/packages/@romefrontend/ast/js/objects/JSStaticPropertyKey.ts
@@ -14,10 +14,10 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSStaticPropertyKey = NodeBaseWithComments & {
+export interface JSStaticPropertyKey extends NodeBaseWithComments {
 	type: "JSStaticPropertyKey";
 	value: JSIdentifier | JSPrivateName | JSStringLiteral | JSNumericLiteral;
-};
+}
 
 export const jsStaticPropertyKey = createQuickBuilder<
 	JSStaticPropertyKey,

--- a/packages/@romefrontend/ast/js/patterns/JSAssignmentArrayPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSAssignmentArrayPattern.ts
@@ -12,12 +12,12 @@
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAssignmentArrayPattern = NodeBaseWithComments & {
+export interface JSAssignmentArrayPattern extends NodeBaseWithComments {
 	type: "JSAssignmentArrayPattern";
 	meta?: JSPatternMeta;
 	elements: Array<JSArrayHole | AnyJSAssignmentPattern>;
 	rest?: AnyJSTargetAssignmentPattern;
-};
+}
 
 export const jsAssignmentArrayPattern = createBuilder<JSAssignmentArrayPattern>(
 	"JSAssignmentArrayPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSAssignmentAssignmentPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSAssignmentAssignmentPattern.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAssignmentAssignmentPattern = NodeBaseWithComments & {
+export interface JSAssignmentAssignmentPattern extends NodeBaseWithComments {
 	type: "JSAssignmentAssignmentPattern";
 	left: AnyJSTargetAssignmentPattern;
 	right: AnyJSExpression;
 	meta?: JSPatternMeta;
-};
+}
 
 export const jsAssignmentAssignmentPattern = createBuilder<JSAssignmentAssignmentPattern>(
 	"JSAssignmentAssignmentPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSAssignmentIdentifier.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSAssignmentIdentifier.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSAssignmentIdentifier = NodeBaseWithComments & {
+export interface JSAssignmentIdentifier extends NodeBaseWithComments {
 	type: "JSAssignmentIdentifier";
 	name: string;
 	definite?: boolean;
-};
+}
 
 export const jsAssignmentIdentifier = createQuickBuilder<
 	JSAssignmentIdentifier,

--- a/packages/@romefrontend/ast/js/patterns/JSAssignmentObjectPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSAssignmentObjectPattern.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAssignmentObjectPattern = NodeBaseWithComments & {
+export interface JSAssignmentObjectPattern extends NodeBaseWithComments {
 	type: "JSAssignmentObjectPattern";
 	meta?: JSPatternMeta;
 	properties: Array<JSAssignmentObjectPatternProperty>;
 	rest: undefined | JSAssignmentIdentifier;
-};
+}
 
 export const jsAssignmentObjectPattern = createBuilder<JSAssignmentObjectPattern>(
 	"JSAssignmentObjectPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSAssignmentObjectPatternProperty.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSAssignmentObjectPatternProperty.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAssignmentObjectPatternProperty = NodeBaseWithComments & {
+export interface JSAssignmentObjectPatternProperty extends NodeBaseWithComments {
 	type: "JSAssignmentObjectPatternProperty";
 	key: AnyJSObjectPropertyKey;
 	value: AnyJSAssignmentPattern;
-};
+}
 
 export const jsAssignmentObjectPatternProperty = createBuilder<JSAssignmentObjectPatternProperty>(
 	"JSAssignmentObjectPatternProperty",

--- a/packages/@romefrontend/ast/js/patterns/JSBindingArrayPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSBindingArrayPattern.ts
@@ -12,12 +12,12 @@
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBindingArrayPattern = NodeBaseWithComments & {
+export interface JSBindingArrayPattern extends NodeBaseWithComments {
 	type: "JSBindingArrayPattern";
 	meta?: JSPatternMeta;
 	elements: Array<JSArrayHole | AnyJSParamBindingPattern>;
 	rest: undefined | AnyJSTargetBindingPattern;
-};
+}
 
 export const jsBindingArrayPattern = createBuilder<JSBindingArrayPattern>(
 	"JSBindingArrayPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSBindingAssignmentPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSBindingAssignmentPattern.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBindingAssignmentPattern = NodeBaseWithComments & {
+export interface JSBindingAssignmentPattern extends NodeBaseWithComments {
 	type: "JSBindingAssignmentPattern";
 	left: AnyJSTargetBindingPattern;
 	right: AnyJSExpression;
 	meta?: JSPatternMeta;
-};
+}
 
 export const jsBindingAssignmentPattern = createBuilder<JSBindingAssignmentPattern>(
 	"JSBindingAssignmentPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSBindingIdentifier.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSBindingIdentifier.ts
@@ -8,12 +8,12 @@
 import {JSPatternMeta, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSBindingIdentifier = NodeBaseWithComments & {
+export interface JSBindingIdentifier extends NodeBaseWithComments {
 	type: "JSBindingIdentifier";
 	name: string;
 	definite?: boolean;
 	meta?: JSPatternMeta;
-};
+}
 
 export const jsBindingIdentifier = createQuickBuilder<
 	JSBindingIdentifier,

--- a/packages/@romefrontend/ast/js/patterns/JSBindingObjectPattern.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSBindingObjectPattern.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBindingObjectPattern = NodeBaseWithComments & {
+export interface JSBindingObjectPattern extends NodeBaseWithComments {
 	meta?: JSPatternMeta;
 	type: "JSBindingObjectPattern";
 	properties: Array<JSBindingObjectPatternProperty>;
 	rest: undefined | JSBindingIdentifier;
-};
+}
 
 export const jsBindingObjectPattern = createBuilder<JSBindingObjectPattern>(
 	"JSBindingObjectPattern",

--- a/packages/@romefrontend/ast/js/patterns/JSBindingObjectPatternProperty.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSBindingObjectPatternProperty.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBindingObjectPatternProperty = NodeBaseWithComments & {
+export interface JSBindingObjectPatternProperty extends NodeBaseWithComments {
 	type: "JSBindingObjectPatternProperty";
 	key: AnyJSObjectPropertyKey;
 	value: AnyJSBindingPattern;
 	meta?: undefined;
-};
+}
 
 export const jsBindingObjectPatternProperty = createBuilder<JSBindingObjectPatternProperty>(
 	"JSBindingObjectPatternProperty",

--- a/packages/@romefrontend/ast/js/patterns/JSPatternMeta.ts
+++ b/packages/@romefrontend/ast/js/patterns/JSPatternMeta.ts
@@ -8,14 +8,14 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSPatternMeta = NodeBaseWithComments & {
+export interface JSPatternMeta extends NodeBaseWithComments {
 	type: "JSPatternMeta";
 	typeAnnotation?: AnyTSPrimary;
 	optional?: boolean;
 	accessibility?: string;
 	definite?: boolean;
 	readonly?: boolean;
-};
+}
 
 export const jsPatternMeta = createQuickBuilder<JSPatternMeta, "typeAnnotation">(
 	"JSPatternMeta",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpAlternation.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpAlternation.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpAlternation = NodeBaseWithComments & {
+export interface JSRegExpAlternation extends NodeBaseWithComments {
 	type: "JSRegExpAlternation";
 	left: AnyJSRegExpExpression;
 	right: JSRegExpSubExpression;
-};
+}
 
 export const jsRegExpAlternation = createBuilder<JSRegExpAlternation>(
 	"JSRegExpAlternation",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpAnyCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpAnyCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpAnyCharacter = NodeBaseWithComments & {
+export interface JSRegExpAnyCharacter extends NodeBaseWithComments {
 	type: "JSRegExpAnyCharacter";
-};
+}
 
 export const jsRegExpAnyCharacter = createBuilder<JSRegExpAnyCharacter>(
 	"JSRegExpAnyCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpCharSet.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpCharSet.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpCharSet = NodeBaseWithComments & {
+export interface JSRegExpCharSet extends NodeBaseWithComments {
 	type: "JSRegExpCharSet";
 	invert?: boolean;
 	body: Array<JSRegExpCharSetRange | AnyJSRegExpEscapedCharacter>;
-};
+}
 
 export const jsRegExpCharSet = createBuilder<JSRegExpCharSet>(
 	"JSRegExpCharSet",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpCharSetRange.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpCharSetRange.ts
@@ -11,11 +11,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpCharSetRange = NodeBaseWithComments & {
+export interface JSRegExpCharSetRange extends NodeBaseWithComments {
 	type: "JSRegExpCharSetRange";
 	start: AnyJSRegExpEscapedCharacter;
 	end: AnyJSRegExpEscapedCharacter;
-};
+}
 
 export const jsRegExpCharSetRange = createBuilder<JSRegExpCharSetRange>(
 	"JSRegExpCharSetRange",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpCharacter.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpCharacter = NodeBaseWithComments & {
+export interface JSRegExpCharacter extends NodeBaseWithComments {
 	type: "JSRegExpCharacter";
 	value: string;
-};
+}
 
 export const jsRegExpCharacter = createBuilder<JSRegExpCharacter>(
 	"JSRegExpCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpControlCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpControlCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpControlCharacter = NodeBaseWithComments & {
+export interface JSRegExpControlCharacter extends NodeBaseWithComments {
 	type: "JSRegExpControlCharacter";
-};
+}
 
 export const jsRegExpControlCharacter = createBuilder<JSRegExpControlCharacter>(
 	"JSRegExpControlCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpDigitCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpDigitCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpDigitCharacter = NodeBaseWithComments & {
+export interface JSRegExpDigitCharacter extends NodeBaseWithComments {
 	type: "JSRegExpDigitCharacter";
-};
+}
 
 export const jsRegExpDigitCharacter = createBuilder<JSRegExpDigitCharacter>(
 	"JSRegExpDigitCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpEndCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpEndCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpEndCharacter = NodeBaseWithComments & {
+export interface JSRegExpEndCharacter extends NodeBaseWithComments {
 	type: "JSRegExpEndCharacter";
-};
+}
 
 export const jsRegExpEndCharacter = createBuilder<JSRegExpEndCharacter>(
 	"JSRegExpEndCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpGroupCapture.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpGroupCapture.ts
@@ -8,11 +8,11 @@
 import {AnyJSRegExpExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpGroupCapture = NodeBaseWithComments & {
+export interface JSRegExpGroupCapture extends NodeBaseWithComments {
 	type: "JSRegExpGroupCapture";
 	expression: AnyJSRegExpExpression;
 	name?: string;
-};
+}
 
 export const jsRegExpGroupCapture = createBuilder<JSRegExpGroupCapture>(
 	"JSRegExpGroupCapture",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpGroupNonCapture.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpGroupNonCapture.ts
@@ -8,7 +8,7 @@
 import {AnyJSRegExpExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpGroupNonCapture = NodeBaseWithComments & {
+export interface JSRegExpGroupNonCapture extends NodeBaseWithComments {
 	type: "JSRegExpGroupNonCapture";
 	expression: AnyJSRegExpExpression;
 	kind?:
@@ -16,7 +16,7 @@ export type JSRegExpGroupNonCapture = NodeBaseWithComments & {
 		| "negative-lookahead"
 		| "positive-lookbehind"
 		| "negative-lookbehind";
-};
+}
 
 export const jsRegExpGroupNonCapture = createBuilder<JSRegExpGroupNonCapture>(
 	"JSRegExpGroupNonCapture",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNamedBackReference.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNamedBackReference.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNamedBackReference = NodeBaseWithComments & {
+export interface JSRegExpNamedBackReference extends NodeBaseWithComments {
 	type: "JSRegExpNamedBackReference";
 	name: string;
-};
+}
 
 export const jsRegExpNamedBackReference = createBuilder<JSRegExpNamedBackReference>(
 	"JSRegExpNamedBackReference",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNonDigitCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNonDigitCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNonDigitCharacter = NodeBaseWithComments & {
+export interface JSRegExpNonDigitCharacter extends NodeBaseWithComments {
 	type: "JSRegExpNonDigitCharacter";
-};
+}
 
 export const jsRegExpNonDigitCharacter = createBuilder<JSRegExpNonDigitCharacter>(
 	"JSRegExpNonDigitCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNonWhiteSpaceCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNonWhiteSpaceCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNonWhiteSpaceCharacter = NodeBaseWithComments & {
+export interface JSRegExpNonWhiteSpaceCharacter extends NodeBaseWithComments {
 	type: "JSRegExpNonWhiteSpaceCharacter";
-};
+}
 
 export const jsRegExpNonWhiteSpaceCharacter = createBuilder<JSRegExpNonWhiteSpaceCharacter>(
 	"JSRegExpNonWhiteSpaceCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNonWordBoundaryCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNonWordBoundaryCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNonWordBoundaryCharacter = NodeBaseWithComments & {
+export interface JSRegExpNonWordBoundaryCharacter extends NodeBaseWithComments {
 	type: "JSRegExpNonWordBoundaryCharacter";
-};
+}
 
 export const jsRegExpNonWordBoundaryCharacter = createBuilder<JSRegExpNonWordBoundaryCharacter>(
 	"JSRegExpNonWordBoundaryCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNonWordCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNonWordCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNonWordCharacter = NodeBaseWithComments & {
+export interface JSRegExpNonWordCharacter extends NodeBaseWithComments {
 	type: "JSRegExpNonWordCharacter";
-};
+}
 
 export const jsRegExpNonWordCharacter = createBuilder<JSRegExpNonWordCharacter>(
 	"JSRegExpNonWordCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpNumericBackReference.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpNumericBackReference.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpNumericBackReference = NodeBaseWithComments & {
+export interface JSRegExpNumericBackReference extends NodeBaseWithComments {
 	type: "JSRegExpNumericBackReference";
 	value: number;
-};
+}
 
 export const jsRegExpNumericBackReference = createBuilder<JSRegExpNumericBackReference>(
 	"JSRegExpNumericBackReference",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpQuantified.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpQuantified.ts
@@ -8,13 +8,13 @@
 import {AnyJSRegExpBodyItem, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpQuantified = NodeBaseWithComments & {
+export interface JSRegExpQuantified extends NodeBaseWithComments {
 	type: "JSRegExpQuantified";
 	target: AnyJSRegExpBodyItem;
 	lazy?: boolean;
 	min: number;
 	max?: number;
-};
+}
 
 export const jsRegExpQuantified = createBuilder<JSRegExpQuantified>(
 	"JSRegExpQuantified",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpStartCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpStartCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpStartCharacter = NodeBaseWithComments & {
+export interface JSRegExpStartCharacter extends NodeBaseWithComments {
 	type: "JSRegExpStartCharacter";
-};
+}
 
 export const jsRegExpStartCharacter = createBuilder<JSRegExpStartCharacter>(
 	"JSRegExpStartCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpSubExpression.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpSubExpression.ts
@@ -8,10 +8,10 @@
 import {AnyJSRegExpBodyItem, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpSubExpression = NodeBaseWithComments & {
+export interface JSRegExpSubExpression extends NodeBaseWithComments {
 	type: "JSRegExpSubExpression";
 	body: Array<AnyJSRegExpBodyItem>;
-};
+}
 
 export const jsRegExpSubExpression = createBuilder<JSRegExpSubExpression>(
 	"JSRegExpSubExpression",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpWhiteSpaceCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpWhiteSpaceCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpWhiteSpaceCharacter = NodeBaseWithComments & {
+export interface JSRegExpWhiteSpaceCharacter extends NodeBaseWithComments {
 	type: "JSRegExpWhiteSpaceCharacter";
-};
+}
 
 export const jsRegExpWhiteSpaceCharacter = createBuilder<JSRegExpWhiteSpaceCharacter>(
 	"JSRegExpWhiteSpaceCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpWordBoundaryCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpWordBoundaryCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpWordBoundaryCharacter = NodeBaseWithComments & {
+export interface JSRegExpWordBoundaryCharacter extends NodeBaseWithComments {
 	type: "JSRegExpWordBoundaryCharacter";
-};
+}
 
 export const jsRegExpWordBoundaryCharacter = createBuilder<JSRegExpWordBoundaryCharacter>(
 	"JSRegExpWordBoundaryCharacter",

--- a/packages/@romefrontend/ast/js/regex/JSRegExpWordCharacter.ts
+++ b/packages/@romefrontend/ast/js/regex/JSRegExpWordCharacter.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSRegExpWordCharacter = NodeBaseWithComments & {
+export interface JSRegExpWordCharacter extends NodeBaseWithComments {
 	type: "JSRegExpWordCharacter";
-};
+}
 
 export const jsRegExpWordCharacter = createBuilder<JSRegExpWordCharacter>(
 	"JSRegExpWordCharacter",

--- a/packages/@romefrontend/ast/js/statements/JSBlockStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSBlockStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSBlockStatement = NodeBaseWithComments & {
+export interface JSBlockStatement extends NodeBaseWithComments {
 	type: "JSBlockStatement";
 	body: Array<AnyJSStatement>;
 	directives?: Array<JSDirective>;
-};
+}
 
 export const jsBlockStatement = createQuickBuilder<JSBlockStatement, "body">(
 	"JSBlockStatement",

--- a/packages/@romefrontend/ast/js/statements/JSBreakStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSBreakStatement.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSBreakStatement = NodeBaseWithComments & {
+export interface JSBreakStatement extends NodeBaseWithComments {
 	type: "JSBreakStatement";
 	label?: JSIdentifier;
-};
+}
 
 export const jsBreakStatement = createBuilder<JSBreakStatement>(
 	"JSBreakStatement",

--- a/packages/@romefrontend/ast/js/statements/JSContinueStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSContinueStatement.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSContinueStatement = NodeBaseWithComments & {
+export interface JSContinueStatement extends NodeBaseWithComments {
 	type: "JSContinueStatement";
 	label?: JSIdentifier;
-};
+}
 
 export const jsContinueStatement = createBuilder<JSContinueStatement>(
 	"JSContinueStatement",

--- a/packages/@romefrontend/ast/js/statements/JSDebuggerStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSDebuggerStatement.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSDebuggerStatement = NodeBaseWithComments & {
+export interface JSDebuggerStatement extends NodeBaseWithComments {
 	type: "JSDebuggerStatement";
-};
+}
 
 export const jsDebuggerStatement = createBuilder<JSDebuggerStatement>(
 	"JSDebuggerStatement",

--- a/packages/@romefrontend/ast/js/statements/JSDoWhileStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSDoWhileStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSDoWhileStatement = NodeBaseWithComments & {
+export interface JSDoWhileStatement extends NodeBaseWithComments {
 	type: "JSDoWhileStatement";
 	body: AnyJSStatement;
 	test: AnyJSExpression;
-};
+}
 
 export const jsDoWhileStatement = createBuilder<JSDoWhileStatement>(
 	"JSDoWhileStatement",

--- a/packages/@romefrontend/ast/js/statements/JSEmptyStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSEmptyStatement.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSEmptyStatement = NodeBaseWithComments & {
+export interface JSEmptyStatement extends NodeBaseWithComments {
 	type: "JSEmptyStatement";
-};
+}
 
 export const jsEmptyStatement = createBuilder<JSEmptyStatement>(
 	"JSEmptyStatement",

--- a/packages/@romefrontend/ast/js/statements/JSExpressionStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSExpressionStatement.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSExpressionStatement = NodeBaseWithComments & {
+export interface JSExpressionStatement extends NodeBaseWithComments {
 	type: "JSExpressionStatement";
 	expression: AnyJSExpression;
-};
+}
 
 export const jsExpressionStatement = createBuilder<JSExpressionStatement>(
 	"JSExpressionStatement",

--- a/packages/@romefrontend/ast/js/statements/JSForInStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSForInStatement.ts
@@ -14,12 +14,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSForInStatement = NodeBaseWithComments & {
+export interface JSForInStatement extends NodeBaseWithComments {
 	type: "JSForInStatement";
 	left: JSVariableDeclaration | AnyJSTargetAssignmentPattern;
 	right: AnyJSExpression;
 	body: AnyJSStatement;
-};
+}
 
 export const jsForInStatement = createBuilder<JSForInStatement>(
 	"JSForInStatement",

--- a/packages/@romefrontend/ast/js/statements/JSForOfStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSForOfStatement.ts
@@ -14,13 +14,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSForOfStatement = NodeBaseWithComments & {
+export interface JSForOfStatement extends NodeBaseWithComments {
 	type: "JSForOfStatement";
 	await?: boolean;
 	left: JSVariableDeclaration | AnyJSTargetAssignmentPattern;
 	right: AnyJSExpression;
 	body: AnyJSStatement;
-};
+}
 
 export const jsForOfStatement = createBuilder<JSForOfStatement>(
 	"JSForOfStatement",

--- a/packages/@romefrontend/ast/js/statements/JSForStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSForStatement.ts
@@ -13,13 +13,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSForStatement = NodeBaseWithComments & {
+export interface JSForStatement extends NodeBaseWithComments {
 	type: "JSForStatement";
 	init?: JSVariableDeclaration | AnyJSExpression;
 	test?: AnyJSExpression;
 	update?: AnyJSExpression;
 	body: AnyJSStatement;
-};
+}
 
 export const jsForStatement = createBuilder<JSForStatement>(
 	"JSForStatement",

--- a/packages/@romefrontend/ast/js/statements/JSFunctionDeclaration.ts
+++ b/packages/@romefrontend/ast/js/statements/JSFunctionDeclaration.ts
@@ -13,13 +13,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSFunctionDeclaration = NodeBaseWithComments & {
+export interface JSFunctionDeclaration extends NodeBaseWithComments {
 	type: "JSFunctionDeclaration";
 	id: JSBindingIdentifier;
 	declare?: boolean;
 	head: JSFunctionHead;
 	body: JSBlockStatement;
-};
+}
 
 export const jsFunctionDeclaration = createBuilder<JSFunctionDeclaration>(
 	"JSFunctionDeclaration",

--- a/packages/@romefrontend/ast/js/statements/JSIfStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSIfStatement.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSIfStatement = NodeBaseWithComments & {
+export interface JSIfStatement extends NodeBaseWithComments {
 	type: "JSIfStatement";
 	test: AnyJSExpression;
 	consequent: AnyJSStatement;
 	alternate?: AnyJSStatement;
-};
+}
 
 export const jsIfStatement = createBuilder<JSIfStatement>(
 	"JSIfStatement",

--- a/packages/@romefrontend/ast/js/statements/JSLabeledStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSLabeledStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSLabeledStatement = NodeBaseWithComments & {
+export interface JSLabeledStatement extends NodeBaseWithComments {
 	type: "JSLabeledStatement";
 	label: JSIdentifier;
 	body: AnyJSStatement;
-};
+}
 
 export const jsLabeledStatement = createBuilder<JSLabeledStatement>(
 	"JSLabeledStatement",

--- a/packages/@romefrontend/ast/js/statements/JSReturnStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSReturnStatement.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSReturnStatement = NodeBaseWithComments & {
+export interface JSReturnStatement extends NodeBaseWithComments {
 	type: "JSReturnStatement";
 	argument?: AnyJSExpression;
-};
+}
 
 export const jsReturnStatement = createQuickBuilder<
 	JSReturnStatement,

--- a/packages/@romefrontend/ast/js/statements/JSSwitchStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSSwitchStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSSwitchStatement = NodeBaseWithComments & {
+export interface JSSwitchStatement extends NodeBaseWithComments {
 	type: "JSSwitchStatement";
 	discriminant: AnyJSExpression;
 	cases: Array<JSSwitchCase>;
-};
+}
 
 export const jsSwitchStatement = createBuilder<JSSwitchStatement>(
 	"JSSwitchStatement",

--- a/packages/@romefrontend/ast/js/statements/JSThrowStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSThrowStatement.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSThrowStatement = NodeBaseWithComments & {
+export interface JSThrowStatement extends NodeBaseWithComments {
 	type: "JSThrowStatement";
 	argument: AnyJSExpression;
-};
+}
 
 export const jsThrowStatement = createBuilder<JSThrowStatement>(
 	"JSThrowStatement",

--- a/packages/@romefrontend/ast/js/statements/JSTryStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSTryStatement.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSTryStatement = NodeBaseWithComments & {
+export interface JSTryStatement extends NodeBaseWithComments {
 	type: "JSTryStatement";
 	block: JSBlockStatement;
 	handler: undefined | JSCatchClause;
 	finalizer: undefined | JSBlockStatement;
-};
+}
 
 export const jsTryStatement = createBuilder<JSTryStatement>(
 	"JSTryStatement",

--- a/packages/@romefrontend/ast/js/statements/JSVariableDeclarationStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSVariableDeclarationStatement.ts
@@ -8,11 +8,11 @@
 import {JSVariableDeclaration, NodeBaseWithComments} from "@romefrontend/ast";
 import {createQuickBuilder} from "../../utils";
 
-export type JSVariableDeclarationStatement = NodeBaseWithComments & {
+export interface JSVariableDeclarationStatement extends NodeBaseWithComments {
 	type: "JSVariableDeclarationStatement";
 	declaration: JSVariableDeclaration;
 	declare?: boolean;
-};
+}
 
 export const jsVariableDeclarationStatement = createQuickBuilder<
 	JSVariableDeclarationStatement,

--- a/packages/@romefrontend/ast/js/statements/JSWhileStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSWhileStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSWhileStatement = NodeBaseWithComments & {
+export interface JSWhileStatement extends NodeBaseWithComments {
 	type: "JSWhileStatement";
 	test: AnyJSExpression;
 	body: AnyJSStatement;
-};
+}
 
 export const jsWhileStatement = createBuilder<JSWhileStatement>(
 	"JSWhileStatement",

--- a/packages/@romefrontend/ast/js/statements/JSWithStatement.ts
+++ b/packages/@romefrontend/ast/js/statements/JSWithStatement.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSWithStatement = NodeBaseWithComments & {
+export interface JSWithStatement extends NodeBaseWithComments {
 	type: "JSWithStatement";
 	object: AnyJSExpression;
 	body: AnyJSStatement;
-};
+}
 
 export const jsWithStatement = createBuilder<JSWithStatement>(
 	"JSWithStatement",

--- a/packages/@romefrontend/ast/js/temp/JSAmbiguousFlowTypeCastExpression.ts
+++ b/packages/@romefrontend/ast/js/temp/JSAmbiguousFlowTypeCastExpression.ts
@@ -13,7 +13,7 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type JSAmbiguousFlowTypeCastExpression = NodeBaseWithComments & {
+export interface JSAmbiguousFlowTypeCastExpression extends NodeBaseWithComments {
 	type: "JSAmbiguousFlowTypeCastExpression";
 	expression: AnyJSExpression | JSSpreadElement;
 	typeAnnotation?: AnyTSPrimary;
@@ -22,7 +22,7 @@ export type JSAmbiguousFlowTypeCastExpression = NodeBaseWithComments & {
 
 	// We should figure out some way to remove this
 	optional?: boolean;
-};
+}
 
 export const jsAmbiguousFlowTypeCastExpression = createBuilder<JSAmbiguousFlowTypeCastExpression>(
 	"JSAmbiguousFlowTypeCastExpression",

--- a/packages/@romefrontend/ast/js/typescript/TSAnyKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSAnyKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSAnyKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSAnyKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSAnyKeywordTypeAnnotation";
-};
+}
 
 export const tsAnyKeywordTypeAnnotation = createBuilder<TSAnyKeywordTypeAnnotation>(
 	"TSAnyKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSArrayType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSArrayType.ts
@@ -8,10 +8,10 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSArrayType = NodeBaseWithComments & {
+export interface TSArrayType extends NodeBaseWithComments {
 	type: "TSArrayType";
 	elementType: AnyTSPrimary;
-};
+}
 
 export const tsArrayType = createBuilder<TSArrayType>(
 	"TSArrayType",

--- a/packages/@romefrontend/ast/js/typescript/TSAsExpression.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSAsExpression.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSAsExpression = NodeBaseWithComments & {
+export interface TSAsExpression extends NodeBaseWithComments {
 	type: "TSAsExpression";
 	typeAnnotation: AnyTSPrimary;
 	expression: AnyJSExpression;
-};
+}
 
 export const tsAsExpression = createBuilder<TSAsExpression>(
 	"TSAsExpression",

--- a/packages/@romefrontend/ast/js/typescript/TSAssignmentAsExpression.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSAssignmentAsExpression.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSAssignmentAsExpression = NodeBaseWithComments & {
+export interface TSAssignmentAsExpression extends NodeBaseWithComments {
 	type: "TSAssignmentAsExpression";
 	typeAnnotation: AnyTSPrimary;
 	expression: AnyJSTargetAssignmentPattern;
-};
+}
 
 export const tsAssignmentAsExpression = createBuilder<TSAssignmentAsExpression>(
 	"TSAssignmentAsExpression",

--- a/packages/@romefrontend/ast/js/typescript/TSAssignmentNonNullExpression.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSAssignmentNonNullExpression.ts
@@ -11,10 +11,10 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSAssignmentNonNullExpression = NodeBaseWithComments & {
+export interface TSAssignmentNonNullExpression extends NodeBaseWithComments {
 	type: "TSAssignmentNonNullExpression";
 	expression: AnyJSTargetAssignmentPattern;
-};
+}
 
 export const tsAssignmentNonNullExpression = createBuilder<TSAssignmentNonNullExpression>(
 	"TSAssignmentNonNullExpression",

--- a/packages/@romefrontend/ast/js/typescript/TSAssignmentTypeAssertion.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSAssignmentTypeAssertion.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSAssignmentTypeAssertion = NodeBaseWithComments & {
+export interface TSAssignmentTypeAssertion extends NodeBaseWithComments {
 	type: "TSAssignmentTypeAssertion";
 	typeAnnotation: AnyTSPrimary;
 	expression: AnyJSTargetAssignmentPattern;
-};
+}
 
 export const tsAssignmentTypeAssertion = createBuilder<TSAssignmentTypeAssertion>(
 	"TSAssignmentTypeAssertion",

--- a/packages/@romefrontend/ast/js/typescript/TSBigIntKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSBigIntKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSBigIntKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSBigIntKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSBigIntKeywordTypeAnnotation";
-};
+}
 
 export const tsBigIntKeywordTypeAnnotation = createBuilder<TSBigIntKeywordTypeAnnotation>(
 	"TSBigIntKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSBigIntLiteralTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSBigIntLiteralTypeAnnotation.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSBigIntLiteralTypeAnnotation = NodeBaseWithComments & {
+export interface TSBigIntLiteralTypeAnnotation extends NodeBaseWithComments {
 	type: "TSBigIntLiteralTypeAnnotation";
 	value: string;
-};
+}
 
 export const tsBigIntLiteralTypeAnnotation = createBuilder<TSBigIntLiteralTypeAnnotation>(
 	"TSBigIntLiteralTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSBooleanKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSBooleanKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSBooleanKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSBooleanKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSBooleanKeywordTypeAnnotation";
-};
+}
 
 export const tsBooleanKeywordTypeAnnotation = createBuilder<TSBooleanKeywordTypeAnnotation>(
 	"TSBooleanKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSBooleanLiteralTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSBooleanLiteralTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSBooleanLiteralTypeAnnotation = NodeBaseWithComments & {
+export interface TSBooleanLiteralTypeAnnotation extends NodeBaseWithComments {
 	type: "TSBooleanLiteralTypeAnnotation";
 	value: boolean;
-};
+}
 
 export const tsBooleanLiteralTypeAnnotation = createBuilder<TSBooleanLiteralTypeAnnotation>(
 	"TSBooleanLiteralTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSCallSignatureDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSCallSignatureDeclaration.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSCallSignatureDeclaration = NodeBaseWithComments & {
+export interface TSCallSignatureDeclaration extends NodeBaseWithComments {
 	type: "TSCallSignatureDeclaration";
 	meta: TSSignatureDeclarationMeta;
 	typeAnnotation?: AnyTSPrimary;
-};
+}
 
 export const tsCallSignatureDeclaration = createBuilder<TSCallSignatureDeclaration>(
 	"TSCallSignatureDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSConditionalType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSConditionalType.ts
@@ -8,13 +8,13 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSConditionalType = NodeBaseWithComments & {
+export interface TSConditionalType extends NodeBaseWithComments {
 	type: "TSConditionalType";
 	checkType: AnyTSPrimary;
 	extendsType: AnyTSPrimary;
 	trueType: AnyTSPrimary;
 	falseType: AnyTSPrimary;
-};
+}
 
 export const tsConditionalType = createBuilder<TSConditionalType>(
 	"TSConditionalType",

--- a/packages/@romefrontend/ast/js/typescript/TSConstKeyword.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSConstKeyword.ts
@@ -1,9 +1,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSConstKeyword = NodeBaseWithComments & {
+export interface TSConstKeyword extends NodeBaseWithComments {
 	type: "TSConstKeyword";
-};
+}
 
 export const tsConstKeyword = createBuilder<TSConstKeyword>(
 	"TSConstKeyword",

--- a/packages/@romefrontend/ast/js/typescript/TSConstructSignatureDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSConstructSignatureDeclaration.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSConstructSignatureDeclaration = NodeBaseWithComments & {
+export interface TSConstructSignatureDeclaration extends NodeBaseWithComments {
 	type: "TSConstructSignatureDeclaration";
 	meta: TSSignatureDeclarationMeta;
 	typeAnnotation?: AnyTSPrimary;
-};
+}
 
 export const tsConstructSignatureDeclaration = createBuilder<TSConstructSignatureDeclaration>(
 	"TSConstructSignatureDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSConstructorType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSConstructorType.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSConstructorType = NodeBaseWithComments & {
+export interface TSConstructorType extends NodeBaseWithComments {
 	type: "TSConstructorType";
 	meta: TSSignatureDeclarationMeta;
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsConstructorType = createBuilder<TSConstructorType>(
 	"TSConstructorType",

--- a/packages/@romefrontend/ast/js/typescript/TSDeclareFunction.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSDeclareFunction.ts
@@ -12,14 +12,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSDeclareFunction = NodeBaseWithComments & {
+export interface TSDeclareFunction extends NodeBaseWithComments {
 	type: "TSDeclareFunction";
 	id: JSBindingIdentifier;
 	head: JSFunctionHead;
 
 	// For consistency with JSFunctionDeclaration, this can mostly be ignored
 	declare?: boolean;
-};
+}
 
 export const tsDeclareFunction = createBuilder<TSDeclareFunction>(
 	"TSDeclareFunction",

--- a/packages/@romefrontend/ast/js/typescript/TSDeclareMethod.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSDeclareMethod.ts
@@ -14,14 +14,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSDeclareMethod = NodeBaseWithComments & {
+export interface TSDeclareMethod extends NodeBaseWithComments {
 	type: "TSDeclareMethod";
 	meta: JSClassPropertyMeta;
 	kind: JSClassMethodKind;
 	key: AnyJSObjectPropertyKey;
 	head: JSFunctionHead;
 	body?: void;
-};
+}
 
 export const tsDeclareMethod = createBuilder<TSDeclareMethod>(
 	"TSDeclareMethod",

--- a/packages/@romefrontend/ast/js/typescript/TSEmptyKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSEmptyKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSEmptyKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSEmptyKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSEmptyKeywordTypeAnnotation";
-};
+}
 
 export const tsEmptyKeywordTypeAnnotation = createBuilder<TSEmptyKeywordTypeAnnotation>(
 	"TSEmptyKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSEnumDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSEnumDeclaration.ts
@@ -12,13 +12,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSEnumDeclaration = NodeBaseWithComments & {
+export interface TSEnumDeclaration extends NodeBaseWithComments {
 	type: "TSEnumDeclaration";
 	id: JSBindingIdentifier;
 	const?: boolean;
 	members: Array<TSEnumMember>;
 	declare?: boolean;
-};
+}
 
 export const tsEnumDeclaration = createBuilder<TSEnumDeclaration>(
 	"TSEnumDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSEnumMember.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSEnumMember.ts
@@ -13,11 +13,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSEnumMember = NodeBaseWithComments & {
+export interface TSEnumMember extends NodeBaseWithComments {
 	type: "TSEnumMember";
 	id: JSStringLiteral | JSIdentifier;
 	initializer?: AnyJSExpression;
-};
+}
 
 export const tsEnumMember = createBuilder<TSEnumMember>(
 	"TSEnumMember",

--- a/packages/@romefrontend/ast/js/typescript/TSExportAssignment.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSExportAssignment.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSExportAssignment = NodeBaseWithComments & {
+export interface TSExportAssignment extends NodeBaseWithComments {
 	type: "TSExportAssignment";
 	expression: AnyJSExpression;
-};
+}
 
 export const tsExportAssignment = createBuilder<TSExportAssignment>(
 	"TSExportAssignment",

--- a/packages/@romefrontend/ast/js/typescript/TSExpressionWithTypeArguments.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSExpressionWithTypeArguments.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSExpressionWithTypeArguments = NodeBaseWithComments & {
+export interface TSExpressionWithTypeArguments extends NodeBaseWithComments {
 	type: "TSExpressionWithTypeArguments";
 	expression: AnyTSEntityName;
 	typeParameters?: TSTypeParameterInstantiation;
-};
+}
 
 export const tsExpressionWithTypeArguments = createBuilder<TSExpressionWithTypeArguments>(
 	"TSExpressionWithTypeArguments",

--- a/packages/@romefrontend/ast/js/typescript/TSExternalModuleReference.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSExternalModuleReference.ts
@@ -8,10 +8,10 @@
 import {JSStringLiteral, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSExternalModuleReference = NodeBaseWithComments & {
+export interface TSExternalModuleReference extends NodeBaseWithComments {
 	type: "TSExternalModuleReference";
 	expression: JSStringLiteral;
-};
+}
 
 export const tsExternalModuleReference = createBuilder<TSExternalModuleReference>(
 	"TSExternalModuleReference",

--- a/packages/@romefrontend/ast/js/typescript/TSFunctionType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSFunctionType.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSFunctionType = NodeBaseWithComments & {
+export interface TSFunctionType extends NodeBaseWithComments {
 	type: "TSFunctionType";
 	meta: TSSignatureDeclarationMeta;
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsFunctionType = createBuilder<TSFunctionType>(
 	"TSFunctionType",

--- a/packages/@romefrontend/ast/js/typescript/TSImportEqualsDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSImportEqualsDeclaration.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSImportEqualsDeclaration = NodeBaseWithComments & {
+export interface TSImportEqualsDeclaration extends NodeBaseWithComments {
 	type: "TSImportEqualsDeclaration";
 	id: JSBindingIdentifier;
 	moduleReference: AnyTSModuleReference;
 	isExport?: boolean;
-};
+}
 
 export const tsImportEqualsDeclaration = createBuilder<TSImportEqualsDeclaration>(
 	"TSImportEqualsDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSImportType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSImportType.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSImportType = NodeBaseWithComments & {
+export interface TSImportType extends NodeBaseWithComments {
 	type: "TSImportType";
 	argument: AnyJSExpression;
 	typeParameters?: TSTypeParameterInstantiation;
 	qualifier?: AnyTSEntityName;
-};
+}
 
 export const tsImportType = createBuilder<TSImportType>(
 	"TSImportType",

--- a/packages/@romefrontend/ast/js/typescript/TSIndexSignature.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSIndexSignature.ts
@@ -12,12 +12,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSIndexSignature = NodeBaseWithComments & {
+export interface TSIndexSignature extends NodeBaseWithComments {
 	type: "TSIndexSignature";
 	readonly?: boolean;
 	key: JSBindingIdentifier;
 	typeAnnotation: undefined | AnyTSPrimary;
-};
+}
 
 export const tsIndexSignature = createBuilder<TSIndexSignature>(
 	"TSIndexSignature",

--- a/packages/@romefrontend/ast/js/typescript/TSIndexedAccessType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSIndexedAccessType.ts
@@ -8,11 +8,11 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSIndexedAccessType = NodeBaseWithComments & {
+export interface TSIndexedAccessType extends NodeBaseWithComments {
 	type: "TSIndexedAccessType";
 	objectType: AnyTSPrimary;
 	indexType: AnyTSPrimary;
-};
+}
 
 export const tsIndexedAccessType = createBuilder<TSIndexedAccessType>(
 	"TSIndexedAccessType",

--- a/packages/@romefrontend/ast/js/typescript/TSInferType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSInferType.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments, TSTypeParameter} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSInferType = NodeBaseWithComments & {
+export interface TSInferType extends NodeBaseWithComments {
 	type: "TSInferType";
 	typeParameter: TSTypeParameter;
-};
+}
 
 export const tsInferType = createBuilder<TSInferType>(
 	"TSInferType",

--- a/packages/@romefrontend/ast/js/typescript/TSInterfaceBody.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSInterfaceBody.ts
@@ -8,10 +8,10 @@
 import {AnyTSTypeElement, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSInterfaceBody = NodeBaseWithComments & {
+export interface TSInterfaceBody extends NodeBaseWithComments {
 	type: "TSInterfaceBody";
 	body: Array<AnyTSTypeElement>;
-};
+}
 
 export const tsInterfaceBody = createBuilder<TSInterfaceBody>(
 	"TSInterfaceBody",

--- a/packages/@romefrontend/ast/js/typescript/TSInterfaceDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSInterfaceDeclaration.ts
@@ -14,14 +14,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSInterfaceDeclaration = NodeBaseWithComments & {
+export interface TSInterfaceDeclaration extends NodeBaseWithComments {
 	type: "TSInterfaceDeclaration";
 	id: JSBindingIdentifier;
 	body: TSInterfaceBody;
 	typeParameters?: TSTypeParameterDeclaration;
 	extends?: Array<TSExpressionWithTypeArguments>;
 	declare?: boolean;
-};
+}
 
 export const tsInterfaceDeclaration = createBuilder<TSInterfaceDeclaration>(
 	"TSInterfaceDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSIntersectionTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSIntersectionTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSIntersectionTypeAnnotation = NodeBaseWithComments & {
+export interface TSIntersectionTypeAnnotation extends NodeBaseWithComments {
 	type: "TSIntersectionTypeAnnotation";
 	types: Array<AnyTSPrimary>;
-};
+}
 
 export const tsIntersectionTypeAnnotation = createBuilder<TSIntersectionTypeAnnotation>(
 	"TSIntersectionTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSMappedType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSMappedType.ts
@@ -14,13 +14,13 @@ import {createBuilder} from "../../utils";
 
 export type TSMappedTypeBoolean = undefined | boolean | "+" | "-";
 
-export type TSMappedType = NodeBaseWithComments & {
+export interface TSMappedType extends NodeBaseWithComments {
 	type: "TSMappedType";
 	typeParameter: TSTypeParameter;
 	typeAnnotation?: AnyTSPrimary;
 	optional?: TSMappedTypeBoolean;
 	readonly?: TSMappedTypeBoolean;
-};
+}
 
 export const tsMappedType = createBuilder<TSMappedType>(
 	"TSMappedType",

--- a/packages/@romefrontend/ast/js/typescript/TSMethodSignature.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSMethodSignature.ts
@@ -13,13 +13,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSMethodSignature = NodeBaseWithComments & {
+export interface TSMethodSignature extends NodeBaseWithComments {
 	key: AnyJSObjectPropertyKey;
 	type: "TSMethodSignature";
 	optional?: boolean;
 	meta: TSSignatureDeclarationMeta;
 	returnType?: AnyTSPrimary;
-};
+}
 
 export const tsMethodSignature = createBuilder<TSMethodSignature>(
 	"TSMethodSignature",

--- a/packages/@romefrontend/ast/js/typescript/TSMixedKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSMixedKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSMixedKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSMixedKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSMixedKeywordTypeAnnotation";
-};
+}
 
 export const tsMixedKeywordTypeAnnotation = createBuilder<TSMixedKeywordTypeAnnotation>(
 	"TSMixedKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSModuleBlock.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSModuleBlock.ts
@@ -8,10 +8,10 @@
 import {AnyJSStatement, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSModuleBlock = NodeBaseWithComments & {
+export interface TSModuleBlock extends NodeBaseWithComments {
 	type: "TSModuleBlock";
 	body: Array<AnyJSStatement>;
-};
+}
 
 export const tsModuleBlock = createBuilder<TSModuleBlock>(
 	"TSModuleBlock",

--- a/packages/@romefrontend/ast/js/typescript/TSModuleDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSModuleDeclaration.ts
@@ -13,13 +13,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSModuleDeclaration = NodeBaseWithComments & {
+export interface TSModuleDeclaration extends NodeBaseWithComments {
 	type: "TSModuleDeclaration";
 	id: JSBindingIdentifier | JSStringLiteral;
 	global?: boolean;
 	body?: TSModuleBlock | TSModuleDeclaration;
 	declare?: boolean;
-};
+}
 
 export const tsModuleDeclaration = createBuilder<TSModuleDeclaration>(
 	"TSModuleDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSNamespaceExportDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNamespaceExportDeclaration.ts
@@ -8,10 +8,10 @@
 import {JSIdentifier, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNamespaceExportDeclaration = NodeBaseWithComments & {
+export interface TSNamespaceExportDeclaration extends NodeBaseWithComments {
 	type: "TSNamespaceExportDeclaration";
 	id: JSIdentifier;
-};
+}
 
 export const tsNamespaceExportDeclaration = createBuilder<TSNamespaceExportDeclaration>(
 	"TSNamespaceExportDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSNeverKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNeverKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNeverKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSNeverKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSNeverKeywordTypeAnnotation";
-};
+}
 
 export const tsNeverKeywordTypeAnnotation = createBuilder<TSNeverKeywordTypeAnnotation>(
 	"TSNeverKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSNonNullExpression.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNonNullExpression.ts
@@ -8,10 +8,10 @@
 import {AnyJSExpression, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNonNullExpression = NodeBaseWithComments & {
+export interface TSNonNullExpression extends NodeBaseWithComments {
 	type: "TSNonNullExpression";
 	expression: AnyJSExpression;
-};
+}
 
 export const tsNonNullExpression = createBuilder<TSNonNullExpression>(
 	"TSNonNullExpression",

--- a/packages/@romefrontend/ast/js/typescript/TSNullKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNullKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNullKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSNullKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSNullKeywordTypeAnnotation";
-};
+}
 
 export const tsNullKeywordTypeAnnotation = createBuilder<TSNullKeywordTypeAnnotation>(
 	"TSNullKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSNumberKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNumberKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNumberKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSNumberKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSNumberKeywordTypeAnnotation";
-};
+}
 
 export const tsNumberKeywordTypeAnnotation = createBuilder<TSNumberKeywordTypeAnnotation>(
 	"TSNumberKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSNumericLiteralTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSNumericLiteralTypeAnnotation.ts
@@ -8,11 +8,11 @@
 import {JSNumericLiteral, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSNumericLiteralTypeAnnotation = NodeBaseWithComments & {
+export interface TSNumericLiteralTypeAnnotation extends NodeBaseWithComments {
 	type: "TSNumericLiteralTypeAnnotation";
 	value: number;
 	format?: JSNumericLiteral["format"];
-};
+}
 
 export const tsNumericLiteralTypeAnnotation = createBuilder<TSNumericLiteralTypeAnnotation>(
 	"TSNumericLiteralTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSObjectKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSObjectKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSObjectKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSObjectKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSObjectKeywordTypeAnnotation";
-};
+}
 
 export const tsObjectKeywordTypeAnnotation = createBuilder<TSObjectKeywordTypeAnnotation>(
 	"TSObjectKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSObjectTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSObjectTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {AnyTSTypeElement, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSObjectTypeAnnotation = NodeBaseWithComments & {
+export interface TSObjectTypeAnnotation extends NodeBaseWithComments {
 	type: "TSObjectTypeAnnotation";
 	members: Array<AnyTSTypeElement>;
-};
+}
 
 export const tsObjectTypeAnnotation = createBuilder<TSObjectTypeAnnotation>(
 	"TSObjectTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSParenthesizedType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSParenthesizedType.ts
@@ -8,10 +8,10 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSParenthesizedType = NodeBaseWithComments & {
+export interface TSParenthesizedType extends NodeBaseWithComments {
 	type: "TSParenthesizedType";
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsParenthesizedType = createBuilder<TSParenthesizedType>(
 	"TSParenthesizedType",

--- a/packages/@romefrontend/ast/js/typescript/TSPropertySignature.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSPropertySignature.ts
@@ -12,13 +12,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSPropertySignature = NodeBaseWithComments & {
+export interface TSPropertySignature extends NodeBaseWithComments {
 	type: "TSPropertySignature";
 	key: AnyJSObjectPropertyKey;
 	optional?: boolean;
 	readonly?: boolean;
 	typeAnnotation?: AnyTSPrimary;
-};
+}
 
 export const tsPropertySignature = createBuilder<TSPropertySignature>(
 	"TSPropertySignature",

--- a/packages/@romefrontend/ast/js/typescript/TSQualifiedName.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSQualifiedName.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSQualifiedName = NodeBaseWithComments & {
+export interface TSQualifiedName extends NodeBaseWithComments {
 	type: "TSQualifiedName";
 	left: AnyTSEntityName;
 	right: JSIdentifier;
-};
+}
 
 export const tsQualifiedName = createBuilder<TSQualifiedName>(
 	"TSQualifiedName",

--- a/packages/@romefrontend/ast/js/typescript/TSSignatureDeclarationMeta.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSSignatureDeclarationMeta.ts
@@ -15,14 +15,14 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSSignatureDeclarationMeta = NodeBaseWithComments & {
+export interface TSSignatureDeclarationMeta extends NodeBaseWithComments {
 	type: "TSSignatureDeclarationMeta";
 	parameters: Array<
 		JSBindingIdentifier | JSBindingObjectPattern | JSBindingArrayPattern
 	>;
 	rest: undefined | AnyJSTargetBindingPattern;
 	typeParameters: undefined | TSTypeParameterDeclaration;
-};
+}
 
 export const tsSignatureDeclarationMeta = createBuilder<TSSignatureDeclarationMeta>(
 	"TSSignatureDeclarationMeta",

--- a/packages/@romefrontend/ast/js/typescript/TSStringKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSStringKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSStringKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSStringKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSStringKeywordTypeAnnotation";
-};
+}
 
 export const tsStringKeywordTypeAnnotation = createBuilder<TSStringKeywordTypeAnnotation>(
 	"TSStringKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSStringLiteralTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSStringLiteralTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSStringLiteralTypeAnnotation = NodeBaseWithComments & {
+export interface TSStringLiteralTypeAnnotation extends NodeBaseWithComments {
 	type: "TSStringLiteralTypeAnnotation";
 	value: string;
-};
+}
 
 export const tsStringLiteralTypeAnnotation = createBuilder<TSStringLiteralTypeAnnotation>(
 	"TSStringLiteralTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSSymbolKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSSymbolKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSSymbolKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSSymbolKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSSymbolKeywordTypeAnnotation";
-};
+}
 
 export const tsSymbolKeywordTypeAnnotation = createBuilder<TSSymbolKeywordTypeAnnotation>(
 	"TSSymbolKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSTemplateLiteralTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTemplateLiteralTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTemplateLiteralTypeAnnotation = NodeBaseWithComments & {
+export interface TSTemplateLiteralTypeAnnotation extends NodeBaseWithComments {
 	type: "TSTemplateLiteralTypeAnnotation";
 	value: string;
-};
+}
 
 export const tsTemplateLiteralTypeAnnotation = createBuilder<TSTemplateLiteralTypeAnnotation>(
 	"TSTemplateLiteralTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSThisType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSThisType.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSThisType = NodeBaseWithComments & {
+export interface TSThisType extends NodeBaseWithComments {
 	type: "TSThisType";
-};
+}
 
 export const tsThisType = createBuilder<TSThisType>(
 	"TSThisType",

--- a/packages/@romefrontend/ast/js/typescript/TSTupleElement.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTupleElement.ts
@@ -5,12 +5,12 @@ import {
 } from "../../index";
 import {createBuilder} from "../../utils";
 
-export type TSTupleElement = NodeBaseWithComments & {
+export interface TSTupleElement extends NodeBaseWithComments {
 	type: "TSTupleElement";
 	name?: JSBindingIdentifier;
 	optional?: boolean;
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsTupleElement = createBuilder<TSTupleElement>(
 	"TSTupleElement",

--- a/packages/@romefrontend/ast/js/typescript/TSTupleType.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTupleType.ts
@@ -8,11 +8,11 @@
 import {NodeBaseWithComments, TSTupleElement} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTupleType = NodeBaseWithComments & {
+export interface TSTupleType extends NodeBaseWithComments {
 	type: "TSTupleType";
 	elementTypes: Array<TSTupleElement>;
 	rest?: TSTupleElement;
-};
+}
 
 export const tsTupleType = createBuilder<TSTupleType>(
 	"TSTupleType",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeAlias.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeAlias.ts
@@ -13,13 +13,13 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeAlias = NodeBaseWithComments & {
+export interface TSTypeAlias extends NodeBaseWithComments {
 	type: "TSTypeAlias";
 	id: JSBindingIdentifier;
 	typeParameters?: TSTypeParameterDeclaration;
 	right: AnyTSPrimary;
 	declare?: boolean | undefined;
-};
+}
 
 export const tsTypeAlias = createBuilder<TSTypeAlias>(
 	"TSTypeAlias",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeAssertion.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeAssertion.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeAssertion = NodeBaseWithComments & {
+export interface TSTypeAssertion extends NodeBaseWithComments {
 	type: "TSTypeAssertion";
 	expression: AnyJSExpression;
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsTypeAssertion = createBuilder<TSTypeAssertion>(
 	"TSTypeAssertion",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeOperator.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeOperator.ts
@@ -8,11 +8,11 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeOperator = NodeBaseWithComments & {
+export interface TSTypeOperator extends NodeBaseWithComments {
 	type: "TSTypeOperator";
 	operator: "keyof" | "unique" | "readonly";
 	typeAnnotation: AnyTSPrimary;
-};
+}
 
 export const tsTypeOperator = createBuilder<TSTypeOperator>(
 	"TSTypeOperator",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeParameter.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeParameter.ts
@@ -8,12 +8,12 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeParameter = NodeBaseWithComments & {
+export interface TSTypeParameter extends NodeBaseWithComments {
 	type: "TSTypeParameter";
 	name: string;
 	default?: AnyTSPrimary;
 	constraint?: AnyTSPrimary;
-};
+}
 
 export const tsTypeParameter = createBuilder<TSTypeParameter>(
 	"TSTypeParameter",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeParameterDeclaration.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeParameterDeclaration.ts
@@ -8,10 +8,10 @@
 import {NodeBaseWithComments, TSTypeParameter} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeParameterDeclaration = NodeBaseWithComments & {
+export interface TSTypeParameterDeclaration extends NodeBaseWithComments {
 	type: "TSTypeParameterDeclaration";
 	params: Array<TSTypeParameter>;
-};
+}
 
 export const tsTypeParameterDeclaration = createBuilder<TSTypeParameterDeclaration>(
 	"TSTypeParameterDeclaration",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeParameterInstantiation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeParameterInstantiation.ts
@@ -8,10 +8,10 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeParameterInstantiation = NodeBaseWithComments & {
+export interface TSTypeParameterInstantiation extends NodeBaseWithComments {
 	type: "TSTypeParameterInstantiation";
 	params: Array<AnyTSPrimary>;
-};
+}
 
 export const tsTypeParameterInstantiation = createBuilder<TSTypeParameterInstantiation>(
 	"TSTypeParameterInstantiation",

--- a/packages/@romefrontend/ast/js/typescript/TSTypePredicate.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypePredicate.ts
@@ -13,12 +13,12 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypePredicate = NodeBaseWithComments & {
+export interface TSTypePredicate extends NodeBaseWithComments {
 	type: "TSTypePredicate";
 	asserts: boolean;
 	parameterName: JSIdentifier | TSThisType;
 	typeAnnotation?: AnyTSPrimary;
-};
+}
 
 export const tsTypePredicate = createBuilder<TSTypePredicate>(
 	"TSTypePredicate",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeQuery.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeQuery.ts
@@ -12,10 +12,10 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeQuery = NodeBaseWithComments & {
+export interface TSTypeQuery extends NodeBaseWithComments {
 	type: "TSTypeQuery";
 	exprName: TSImportType | AnyTSEntityName;
-};
+}
 
 export const tsTypeQuery = createBuilder<TSTypeQuery>(
 	"TSTypeQuery",

--- a/packages/@romefrontend/ast/js/typescript/TSTypeReference.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSTypeReference.ts
@@ -12,11 +12,11 @@ import {
 } from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeReference = NodeBaseWithComments & {
+export interface TSTypeReference extends NodeBaseWithComments {
 	type: "TSTypeReference";
 	typeName: AnyTSEntityName;
 	typeParameters?: TSTypeParameterInstantiation;
-};
+}
 
 export const tsTypeReference = createBuilder<TSTypeReference>(
 	"TSTypeReference",

--- a/packages/@romefrontend/ast/js/typescript/TSUndefinedKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSUndefinedKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSUndefinedKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSUndefinedKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSUndefinedKeywordTypeAnnotation";
-};
+}
 
 export const tsUndefinedKeywordTypeAnnotation = createBuilder<TSUndefinedKeywordTypeAnnotation>(
 	"TSUndefinedKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSUnionTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSUnionTypeAnnotation.ts
@@ -8,10 +8,10 @@
 import {AnyTSPrimary, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSUnionTypeAnnotation = NodeBaseWithComments & {
+export interface TSUnionTypeAnnotation extends NodeBaseWithComments {
 	type: "TSUnionTypeAnnotation";
 	types: Array<AnyTSPrimary>;
-};
+}
 
 export const tsUnionTypeAnnotation = createBuilder<TSUnionTypeAnnotation>(
 	"TSUnionTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSUnknownKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSUnknownKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSUnknownKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSUnknownKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSUnknownKeywordTypeAnnotation";
-};
+}
 
 export const tsUnknownKeywordTypeAnnotation = createBuilder<TSUnknownKeywordTypeAnnotation>(
 	"TSUnknownKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/js/typescript/TSVoidKeywordTypeAnnotation.ts
+++ b/packages/@romefrontend/ast/js/typescript/TSVoidKeywordTypeAnnotation.ts
@@ -8,9 +8,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type TSVoidKeywordTypeAnnotation = NodeBaseWithComments & {
+export interface TSVoidKeywordTypeAnnotation extends NodeBaseWithComments {
 	type: "TSVoidKeywordTypeAnnotation";
-};
+}
 
 export const tsVoidKeywordTypeAnnotation = createBuilder<TSVoidKeywordTypeAnnotation>(
 	"TSVoidKeywordTypeAnnotation",

--- a/packages/@romefrontend/ast/markdown/blocks/MarkdownCodeBlock.ts
+++ b/packages/@romefrontend/ast/markdown/blocks/MarkdownCodeBlock.ts
@@ -1,9 +1,9 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MarkdownCodeBlock = NodeBaseWithComments & {
+export interface MarkdownCodeBlock extends NodeBaseWithComments {
 	type: "MarkdownCodeBlock";
-};
+}
 
 export const markdownCodeBlock = createBuilder<MarkdownCodeBlock>(
 	"MarkdownCodeBlock",

--- a/packages/@romefrontend/ast/markdown/blocks/MarkdownDividerBlock.ts
+++ b/packages/@romefrontend/ast/markdown/blocks/MarkdownDividerBlock.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MarkdownDividerBlock = NodeBaseWithComments & {
+export interface MarkdownDividerBlock extends NodeBaseWithComments {
 	type: "MarkdownDividerBlock";
 	value: string;
-};
+}
 
 export const markdownDividerBlock = createBuilder<MarkdownDividerBlock>(
 	"MarkdownDividerBlock",

--- a/packages/@romefrontend/ast/markdown/blocks/MarkdownHeadingBlock.ts
+++ b/packages/@romefrontend/ast/markdown/blocks/MarkdownHeadingBlock.ts
@@ -3,11 +3,11 @@ import {createBuilder} from "../../utils";
 
 // # Something
 // #### Some other thing
-export type MarkdownHeadingBlock = NodeBaseWithComments & {
+export interface MarkdownHeadingBlock extends NodeBaseWithComments {
 	type: "MarkdownHeadingBlock";
 	level: number;
 	value: string;
-};
+}
 
 export const markdownHeadingBlock = createBuilder<MarkdownHeadingBlock>(
 	"MarkdownHeadingBlock",

--- a/packages/@romefrontend/ast/markdown/blocks/MarkdownListBlock.ts
+++ b/packages/@romefrontend/ast/markdown/blocks/MarkdownListBlock.ts
@@ -1,11 +1,11 @@
 import {MarkdownListItem, NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MarkdownListBlock = NodeBaseWithComments & {
+export interface MarkdownListBlock extends NodeBaseWithComments {
 	type: "MarkdownListBlock";
 	ordered: boolean;
 	children: Array<MarkdownListItem>;
-};
+}
 
 export const markdownListBlock = createBuilder<MarkdownListBlock>(
 	"MarkdownListBlock",

--- a/packages/@romefrontend/ast/markdown/blocks/MarkdownQuoteBlock.ts
+++ b/packages/@romefrontend/ast/markdown/blocks/MarkdownQuoteBlock.ts
@@ -3,10 +3,10 @@ import {createBuilder} from "../../utils";
 import {MarkdownQuoteChildren} from "@romefrontend/ast/markdown/unions";
 
 // > this quote
-export type MarkdownQuoteBlock = NodeBaseWithComments & {
+export interface MarkdownQuoteBlock extends NodeBaseWithComments {
 	type: "MarkdownQuoteBlock";
 	children: Array<MarkdownQuoteChildren>;
-};
+}
 
 export const markdownQuoteBlock = createBuilder<MarkdownQuoteBlock>(
 	"MarkdownQuoteBlock",

--- a/packages/@romefrontend/ast/markdown/core/MarkdownListItem.ts
+++ b/packages/@romefrontend/ast/markdown/core/MarkdownListItem.ts
@@ -2,13 +2,13 @@ import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 import {MarkdownListChildren} from "@romefrontend/ast/markdown/unions";
 
-export type MarkdownListItem = NodeBaseWithComments & {
+export interface MarkdownListItem extends NodeBaseWithComments {
 	type: "MarkdownListItem";
 	checked: boolean | undefined;
 	children: Array<MarkdownListChildren>;
 	// the value of ordered list: 1./-/*
 	value: string | undefined;
-};
+}
 
 export const markdownListItem = createBuilder<MarkdownListItem>(
 	"MarkdownListItem",

--- a/packages/@romefrontend/ast/markdown/core/MarkdownParagraph.ts
+++ b/packages/@romefrontend/ast/markdown/core/MarkdownParagraph.ts
@@ -2,10 +2,10 @@ import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 import {AnyMarkdownInlineNode} from "@romefrontend/ast/markdown/unions";
 
-export type MarkdownParagraph = NodeBaseWithComments & {
+export interface MarkdownParagraph extends NodeBaseWithComments {
 	type: "MarkdownParagraph";
 	children: Array<AnyMarkdownInlineNode>;
-};
+}
 
 export const markdownParagraph = createBuilder<MarkdownParagraph>(
 	"MarkdownParagraph",

--- a/packages/@romefrontend/ast/markdown/core/MarkdownRoot.ts
+++ b/packages/@romefrontend/ast/markdown/core/MarkdownRoot.ts
@@ -2,11 +2,11 @@ import {NodeBaseWithComments, RootBase} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 import {AnyMarkdownNode} from "@romefrontend/ast/markdown/unions";
 
-export type MarkdownRoot = NodeBaseWithComments &
-	RootBase & {
-		type: "MarkdownRoot";
-		body: Array<AnyMarkdownNode>;
-	};
+export interface MarkdownRoot extends NodeBaseWithComments,
+RootBase {
+	type: "MarkdownRoot";
+	body: Array<AnyMarkdownNode>;
+}
 
 export const markdownRoot = createBuilder<MarkdownRoot>(
 	"MarkdownRoot",

--- a/packages/@romefrontend/ast/markdown/core/MarkdownText.ts
+++ b/packages/@romefrontend/ast/markdown/core/MarkdownText.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MarkdownText = NodeBaseWithComments & {
+export interface MarkdownText extends NodeBaseWithComments {
 	type: "MarkdownText";
 	value: string;
-};
+}
 
 export const markdownText = createBuilder<MarkdownText>(
 	"MarkdownText",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownAutomaticLinkInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownAutomaticLinkInline.ts
@@ -3,9 +3,9 @@ import {createBuilder} from "../../utils";
 
 // <something.com/>
 // TODO here we have to obscure the email
-export type MarkdownAutomaticLinkInline = NodeBaseWithComments & {
+export interface MarkdownAutomaticLinkInline extends NodeBaseWithComments {
 	type: "MarkdownAutomaticLinkInline";
-};
+}
 
 export const markdownAutomaticLinkInline = createBuilder<MarkdownAutomaticLinkInline>(
 	"MarkdownAutomaticLinkInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownBoldInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownBoldInline.ts
@@ -2,10 +2,10 @@ import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
 // **something**
-export type MarkdownBoldInline = NodeBaseWithComments & {
+export interface MarkdownBoldInline extends NodeBaseWithComments {
 	type: "MarkdownBoldInline";
 	value: string;
-};
+}
 
 export const markdownBoldInline = createBuilder<MarkdownBoldInline>(
 	"MarkdownBoldInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownCodeInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownCodeInline.ts
@@ -1,10 +1,10 @@
 import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
-export type MarkdownCodeInline = NodeBaseWithComments & {
+export interface MarkdownCodeInline extends NodeBaseWithComments {
 	type: "MarkdownCodeInline";
 	value: string;
-};
+}
 
 export const markdownCodeInline = createBuilder<MarkdownCodeInline>(
 	"MarkdownCodeInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownDefinitionInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownDefinitionInline.ts
@@ -2,14 +2,14 @@ import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
 // [link]: www.example.com "Title"
-export type MarkdownDefinitionInline = NodeBaseWithComments & {
+export interface MarkdownDefinitionInline extends NodeBaseWithComments {
 	type: "MarkdownDefinitionInline";
 	value: string;
 	url: string;
 	title: string;
 	// TODO make sure identifier is unique somewhere/somehow
 	identifier: string;
-};
+}
 
 export const markdownDefinitionInline = createBuilder<MarkdownDefinitionInline>(
 	"MarkdownDefinitionInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownEmphasisInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownEmphasisInline.ts
@@ -2,10 +2,10 @@ import {NodeBaseWithComments} from "@romefrontend/ast";
 import {createBuilder} from "../../utils";
 
 // *emphasis*
-export type MarkdownEmphasisInline = NodeBaseWithComments & {
+export interface MarkdownEmphasisInline extends NodeBaseWithComments {
 	type: "MarkdownEmphasisInline";
 	value: string;
-};
+}
 
 export const markdownEmphasisInline = createBuilder<MarkdownEmphasisInline>(
 	"MarkdownEmphasisInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownImageInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownImageInline.ts
@@ -4,11 +4,11 @@ import {MarkdownReference} from "@romefrontend/ast/markdown/unions";
 
 // ![Atl text](//url)
 // ![Atl text] [1]
-export type MarkdownImageInline = NodeBaseWithComments & {
+export interface MarkdownImageInline extends NodeBaseWithComments {
 	type: "MarkdownImageInline";
 	url: MarkdownReference;
 	altText: string;
-};
+}
 
 export const markdownImageInline = createBuilder<MarkdownImageInline>(
 	"MarkdownImageInline",

--- a/packages/@romefrontend/ast/markdown/inline/MarkdownLinkInline.ts
+++ b/packages/@romefrontend/ast/markdown/inline/MarkdownLinkInline.ts
@@ -3,12 +3,12 @@ import {createBuilder} from "../../utils";
 import {MarkdownReference} from "@romefrontend/ast/markdown/unions";
 
 // [link](www.example.com)
-export type MarkdownLinkInline = NodeBaseWithComments & {
+export interface MarkdownLinkInline extends NodeBaseWithComments {
 	type: "MarkdownLinkInline";
 	value: string;
 	url: MarkdownReference;
 	title?: string;
-};
+}
 
 export const markdownLinkInline = createBuilder<MarkdownLinkInline>(
 	"MarkdownLinkInline",

--- a/packages/@romefrontend/ast/utils.ts
+++ b/packages/@romefrontend/ast/utils.ts
@@ -32,10 +32,10 @@ type VisitorKeys<T> = {[K in JustNodeKeys<T>]: true};
 
 type BindingKeys<T> = {[K in JustNodeKeys<T>]?: true};
 
-type CreateBuilderOptions<Node> = {
+interface CreateBuilderOptions<Node> {
 	bindingKeys: BindingKeys<Node>;
 	visitorKeys: VisitorKeys<Node>;
-};
+}
 
 function declareBuilder<Node>(type: string, opts: CreateBuilderOptions<Node>) {
 	nodeNames.add(type);

--- a/packages/@romefrontend/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romefrontend/core/common/bridges/WorkerBridge.ts
@@ -259,6 +259,7 @@ export default class WorkerBridge extends Bridge {
 			ref: JSONFileReference;
 			options: WorkerParseOptions;
 		},
+		// @ts-ignore
 		AnyRoot
 	>({name: "parse", direction: "server->client"});
 

--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -38,9 +38,9 @@ export async function main(
 			import {NodeBaseWithComments} from "@romefrontend/ast";
 			import {createBuilder} from "../../utils";
 
-			export type ${nodeType} = NodeBaseWithComments & {
+			interface ${nodeType} extends NodeBaseWithComments {
 				type: "${nodeType}";
-			};
+			}
 
 			export const ${builderName} = createBuilder<${nodeType}>("${nodeType}", {
 				bindingKeys: {},


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

With intersections a full type check was taking 80s. Using interfaces it now takes 17s. I assume it's because the inheritance chain is more clear, and since we have a huge union of all possible nodes, when we refer to it and access properties defined on `NodeBaseWithComments` it had to check every single member.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

CI