### PR TITLE
Website: Fix table of contents

### DIFF
--- a/website/static/js/index.js
+++ b/website/static/js/index.js
@@ -106,7 +106,7 @@ const toc = {
 			scrollToHeading(hash);
 
 			if (isMobile()) {
-				toggleMobileNav(event);
+				toggleMobileTOC(event);
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
On mobile, when clicking a link in the toc, the navigation sidebar was opening. This PR fixes the issue, and the toc sidebar closes when a toc link is clicked.

## Test Plan
N/A
