### PR TITLE
Update Rome volunteers link on homepage

### DIFF
--- a/website/src/index.md
+++ b/website/src/index.md
@@ -14,7 +14,7 @@ layout: layouts/homepage.njk
 
 **Rome** has strong conventions and aims to have minimal configuration. Read more about our [project philosophy](https://romefrontend.dev/about#philosophy).
 
-**Rome** is maintained by a [team of volunteers](https://romefrontend.dev/contributing/team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
+**Rome** is maintained by a [team of volunteers](https://romefrontend.dev/about/#team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
 
 ## Preview
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

I was clicking through the homepage at https://romefrontend.dev/ and noticed the `team of volunteers` link points to a page, `https://romefrontend.dev/contributing/team`, that does not exist:

![image](https://user-images.githubusercontent.com/13544620/88607957-2c6f4800-d046-11ea-84e1-daa1caaf4621.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I noticed the link in the `README` points to the correct URL, and updated the website link accordingly. 

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New link worked locally via website build steps at https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md#website. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
