### PR TITLE
fix: added `--tags` when pushing a new version to git

### DIFF
--- a/scripts/update-version.ts
+++ b/scripts/update-version.ts
@@ -79,7 +79,7 @@ export async function main(args: Array<string>) {
 	// Create commit and tag
 	await exec("git", ["commit", "-am", `Release v${version}`]);
 	await exec("git", ["tag", `v${version}`]);
-	await exec("git", ["push"]);
+	await exec("git", ["push", "--tags"]);
 	await exec("git", ["push", "origin", `v${version}`]);
 
 	reporter.success(markup`Created tag and release commit. To publish run:`);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

This fixes the update version script. 
It adds `--tags` to the push command. By default the command `git push` doesn't push newly local tags.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
