### PR TITLE
feat: lint suggestions for properties for js/confusingLanguage

### DIFF
--- a/internal/compiler/lint/rules/js/confusingLanguage.test.md
+++ b/internal/compiler/lint/rules/js/confusingLanguage.test.md
@@ -173,3 +173,87 @@ someDenylist;
 SOME_DENYLIST;
 
 ```
+
+### `6`
+
+```
+
+ lint/js/confusingLanguage/reject/7/file.ts:1 lint/js/confusingLanguage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The word blacklist can be considered racially charged language.
+
+    const payload = {blacklist: []};
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  ℹ See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/ for a more detailed explanation.
+
+  ℹ Consider using denylist instead
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `6: formatted`
+
+```
+const payload = {blacklist: []};
+
+```
+
+### `7`
+
+```
+
+ lint/js/confusingLanguage/reject/8/file.ts:1 lint/js/confusingLanguage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The word blacklist can be considered racially charged language.
+
+    payload.blacklist = [];
+    ^^^^^^^^^^^^^^^^^
+
+  ℹ See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/ for a more detailed explanation.
+
+  ℹ Consider using denylist instead
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `7: formatted`
+
+```
+payload.blacklist = [];
+
+```
+
+### `8`
+
+```
+
+ lint/js/confusingLanguage/reject/9/file.ts:1 lint/js/confusingLanguage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The word blacklist can be considered racially charged language.
+
+    payload.blacklist();
+    ^^^^^^^^^^^^^^^^^
+
+  ℹ See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/ for a more detailed explanation.
+
+  ℹ Consider using denylist instead
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `8: formatted`
+
+```
+payload.blacklist();
+
+```

--- a/internal/compiler/lint/rules/js/confusingLanguage.test.rjson
+++ b/internal/compiler/lint/rules/js/confusingLanguage.test.rjson
@@ -7,4 +7,7 @@ blacklist	*/"
 	"BLACKLIST;"
 	"someBlacklist;"
 	"SOME_BLACKLIST;"
+	"const payload = {blacklist: []};"
+	"payload.blacklist = [];"
+	"payload.blacklist();"
 ]

--- a/internal/compiler/lint/rules/js/confusingLanguage.ts
+++ b/internal/compiler/lint/rules/js/confusingLanguage.ts
@@ -135,7 +135,7 @@ function check(
 export default createVisitor({
 	name: "js/inconsiderateLanguage",
 	enter(path) {
-		const {node, context} = path;
+		const {node, context, parent} = path;
 
 		const {loc} = node;
 		if (loc !== undefined) {
@@ -147,6 +147,10 @@ export default createVisitor({
 			if (isIdentifierish(node)) {
 				value = node.name;
 			}
+
+			const isSafeFix =
+				parent.type !== "JSStaticPropertyKey" &&
+				parent.type !== "JSStaticMemberProperty";
 
 			if (value !== undefined) {
 				// Produce diagnostics
@@ -160,7 +164,7 @@ export default createVisitor({
 							suggestion,
 							advice,
 						),
-						{tags: {fixable: true}},
+						{tags: {fixable: isSafeFix}},
 					));
 
 					if (suppressed) {
@@ -169,7 +173,7 @@ export default createVisitor({
 				}
 
 				// Autofix if not suppressed
-				if (results.length > 0 && !suppressed) {
+				if (results.length > 0 && isSafeFix && !suppressed) {
 					if (node.type === "CommentBlock" || node.type === "CommentLine") {
 						return signals.replace({
 							...node,

--- a/website/src/docs/lint/rules/js/confusingLanguage.md
+++ b/website/src/docs/lint/rules/js/confusingLanguage.md
@@ -12,7 +12,7 @@ eleventyNavigation:
 
 MISSING DOCUMENTATION
 
-<!-- GENERATED:START(hash:2fe0b0a536f9336b4a6e21baf4b0453e091128fb,id:main) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:c982488a5e77e12ec46707352f24b059935e9577,id:main) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 ### Invalid
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">//	the	blacklist</span></code></pre>{% endraw %}
@@ -120,6 +120,60 @@ MISSING DOCUMENTATION
     <span style="color: DodgerBlue;">detailed explanation.</span>
 
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Consider using </span><span style="color: DodgerBlue;"><strong>DENYLIST</strong></span><span style="color: DodgerBlue;"> instead</span>
+
+</code></pre>{% endraw %}
+
+---------------
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">const</span> <span class="token variable">payload</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token variable">blacklist</span><span class="token punctuation">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">}</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1</span> <strong>lint/js/confusingLanguage</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">The word </span><span style="color: Tomato;"><strong>blacklist</strong></span><span style="color: Tomato;"> can be considered racially charged language.</span>
+
+    <span class="token keyword">const</span> <span class="token variable">payload</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token variable">blacklist</span><span class="token punctuation">:</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
+    <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">See </span><span style="color: DodgerBlue;"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/</a></span><span style="color: DodgerBlue;"> for a more</span>
+    <span style="color: DodgerBlue;">detailed explanation.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Consider using </span><span style="color: DodgerBlue;"><strong>denylist</strong></span><span style="color: DodgerBlue;"> instead</span>
+
+</code></pre>{% endraw %}
+
+---------------
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token variable">payload</span><span class="token punctuation">.</span><span class="token variable">blacklist</span> <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1</span> <strong>lint/js/confusingLanguage</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">The word </span><span style="color: Tomato;"><strong>blacklist</strong></span><span style="color: Tomato;"> can be considered racially charged language.</span>
+
+    <span class="token variable">payload</span><span class="token punctuation">.</span><span class="token variable">blacklist</span> <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">;</span>
+    <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">See </span><span style="color: DodgerBlue;"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/</a></span><span style="color: DodgerBlue;"> for a more</span>
+    <span style="color: DodgerBlue;">detailed explanation.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Consider using </span><span style="color: DodgerBlue;"><strong>denylist</strong></span><span style="color: DodgerBlue;"> instead</span>
+
+</code></pre>{% endraw %}
+
+---------------
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token variable">payload</span><span class="token punctuation">.</span><span class="token variable">blacklist</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1</span> <strong>lint/js/confusingLanguage</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">The word </span><span style="color: Tomato;"><strong>blacklist</strong></span><span style="color: Tomato;"> can be considered racially charged language.</span>
+
+    <span class="token variable">payload</span><span class="token punctuation">.</span><span class="token variable">blacklist</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+    <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">See </span><span style="color: DodgerBlue;"><a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/">https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6148600/</a></span><span style="color: DodgerBlue;"> for a more</span>
+    <span style="color: DodgerBlue;">detailed explanation.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Consider using </span><span style="color: DodgerBlue;"><strong>denylist</strong></span><span style="color: DodgerBlue;"> instead</span>
 
 </code></pre>{% endraw %}
 <!-- GENERATED:END(id:main) -->


### PR DESCRIPTION
## Summary

This pull request updates the `js/confusingLanguage` lint rule in preparation for a release to use lint suggestions instead of auto-fixes when working with object properties and member expressions. This allows `check --apply` to be used safely since unsafe property auto-fixes will no longer be applied.

I realize that the words detected in this rule and where their source of truth will change as part of #793, and I'm happy to take on the work of updating this rule once the required configuration changes land (cc @sebmck).

Resolves #760

## Test Plan

```sh
./rome test
```
