### PR TITLE
style: inline code background color for better distinction

### DIFF
--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -33,8 +33,9 @@ code {
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	-moz-tab-size: 2;
 	tab-size: 2;
-	background-color: rgba(0, 0, 0, 0.08);
-	padding: 0 5px;
+	background-color: var(--inline-code-background-color);
+	padding: 2px 5px;
+	border-radius: 2px;
 }
 
 pre code {

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -39,6 +39,7 @@
 	--color-scheme-switcher-color: #{$gray-4};
 	--search-input-background-color: rgba(0, 0, 0, 0.07);
 	--table-even-row-color: rgba(0, 0, 0, 0.05);
+	--inline-code-background-color: rgba(0, 0, 0, 0.08);
 }
 
 @mixin dark-root {
@@ -63,6 +64,7 @@
 	--color-scheme-switcher-color: #000;
 	--search-input-background-color: rgba(0, 0, 0, 0.09);
 	--table-even-row-color: rgba(0, 0, 0, 0.09);
+	--inline-code-background-color: rgba(68, 73, 80, 0.7);
 }
 
 html[data-theme="dark"] {


### PR DESCRIPTION
## Summary

Improve ability to discern `inline-code` elements in docs.
PR adds and uses a CSS variable for the same.
Also adds `border-radius` and `padding`.

#### Before
![Screenshot_2020-08-07  — Rome Frontend Toolchain - Before](https://user-images.githubusercontent.com/11270438/89623665-a3140d00-d8b2-11ea-9ea9-51006121e583.png)

#### After
![Screenshot_2020-08-07  — Rome Frontend Toolchain - After](https://user-images.githubusercontent.com/11270438/89623654-9d1e2c00-d8b2-11ea-994b-1361a1ce2269.png)
