### PR TITLE
Fixes link to Getting Started documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ rome init
 
 This file is used to configure Rome and indicates the boundaries of your project.
 
-See [Getting Started](https://romefrontend.dev/docs/getting-started/) for more usage instructions.
+See [Getting Started](https://romefrontend.dev/#getting-started) for more usage instructions.
 
 ## Philosophy
 


### PR DESCRIPTION
## Summary

This is a quick fix to the `Getting Started` documentation which currently redirect to a "Page Not Found".

## Test Plan

Chicking that's the correct link that I set
