### PR TITLE
Fix documentation 404 links

### DIFF
--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -10,10 +10,10 @@ Clear all artifacts from the cache directory.
 
 Used to find problems in your project. This includes:
 
-- Dependency verification
-- Formatting
-- Linting
-- `package.json` validation
+ - Dependency verification
+ - Formatting
+ - Linting
+ - `package.json` validation
 
 See [Linting: Command Usage](#command-usage) for more usage information.
 
@@ -69,8 +69,8 @@ Show the config location that would be modified.
 
 This command assists in the creation of a new Rome project. Actions that are performed:
 
-- `rome.rjson` is created that serves as your [project configuration](#project-configuration).
-- `.editorconfig` is created that correctly sets indentation for editors that support [EditorConfig](https://editorconfig.org/).
+ - `rome.rjson` is created that serves as your [project configuration](#project-configuration).
+ - `.editorconfig` is created that correctly sets indentation for editors that support [EditorConfig](https://editorconfig.org/).
 
 **Flags**
 
@@ -78,8 +78,8 @@ This command assists in the creation of a new Rome project. Actions that are per
 
 Additional operations are applied with this flag:
 
-- `rome check --apply` is ran which will automatically format and autofix your files.
-- Global variables are extracted from previous errors and automatically added to your project config.
+ - `rome check --apply` is ran which will automatically format and autofix your files.
+ - Global variables are extracted from previous errors and automatically added to your project config.
 
 **Uncomitted changes and `--apply`**
 

--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -10,10 +10,10 @@ Clear all artifacts from the cache directory.
 
 Used to find problems in your project. This includes:
 
- - Dependency verification
- - Formatting
- - Linting
- - `package.json` validation
+- Dependency verification
+- Formatting
+- Linting
+- `package.json` validation
 
 See [Linting: Command Usage](#command-usage) for more usage information.
 
@@ -35,7 +35,7 @@ Reformat all files without applying any fixes.
 
 #### `rome config`
 
-Used to modify project configuration. These commands work with all Rome project config locations (see [supported locations](/docs/project-config#supported-locations) for more info). When formatting a project config written with [RJSON](/docs/rjson), comments will be retained.
+Used to modify project configuration. These commands work with all Rome project config locations (see [supported locations](#supported-locations) for more info). When formatting a project config written with [RJSON](#rome-json), comments will be retained.
 
 Before your project config is saved, we will validate it for errors. It is not possible to save an invalid config with `rome config`.
 
@@ -69,8 +69,8 @@ Show the config location that would be modified.
 
 This command assists in the creation of a new Rome project. Actions that are performed:
 
- - `rome.rjson` is created that serves as your [project configuration](/docs/project-config).
- - `.editorconfig` is created that correctly sets indentation for editors that support [EditorConfig](https://editorconfig.org/).
+- `rome.rjson` is created that serves as your [project configuration](#project-configuration).
+- `.editorconfig` is created that correctly sets indentation for editors that support [EditorConfig](https://editorconfig.org/).
 
 **Flags**
 
@@ -78,8 +78,8 @@ This command assists in the creation of a new Rome project. Actions that are per
 
 Additional operations are applied with this flag:
 
- - `rome check --apply` is ran which will automatically format and autofix your files.
- - Global variables are extracted from previous errors and automatically added to your project config.
+- `rome check --apply` is ran which will automatically format and autofix your files.
+- Global variables are extracted from previous errors and automatically added to your project config.
 
 **Uncomitted changes and `--apply`**
 
@@ -89,7 +89,7 @@ Since this command can be destructive and may have unintended consequences, we c
 
 #### `rome logs`
 
-Alias for `rome noop --logs --hang`. See [`--logs` documentation](/docs/cli/debugging#--logs) for more info.
+Alias for `rome noop --logs --hang`. See [`--logs` documentation](#--logs) for more info.
 
 This command will never complete.
 
@@ -107,7 +107,7 @@ This command does nothing. Used in conjunction with other global flags such as [
 
 #### `rome rage`
 
-Alias for `rome noop --rage`. See [`--rage` documentation](/docs/cli/debugging#--rage) for more info.
+Alias for `rome noop --rage`. See [`--rage` documentation](#rome-rage) for more info.
 
 #### `rome recover`
 
@@ -145,7 +145,7 @@ Clear the entire contents of the recovery store.
 
 #### `rome restart`
 
-Equivalent to running [`rome stop`](/docs/cli/commands/stop) and then [`rome start`](/docs/cli/commands/start).
+Equivalent to running [`rome stop`](#rome-stop) and then [`rome start`](#rome-start).
 
 #### `rome start`
 

--- a/website/src/_includes/docs/linting.md
+++ b/website/src/_includes/docs/linting.md
@@ -77,8 +77,8 @@ To use the Rome linter we require usage of the Rome formatter. We offer powerful
 
 Notable formatting choices include:
 
-- Indentation: Hard tabs. [Improved accessibility](https://github.com/romefrontend/rome/issues/425) over two-spaced tabs.
-- Double string quotes. Consistent quote style across all supported languages.
+ - Indentation: Hard tabs. [Improved accessibility](https://github.com/romefrontend/rome/issues/425) over two-spaced tabs.
+ - Double string quotes. Consistent quote style across all supported languages.
 
 ### Applying Fixes
 

--- a/website/src/_includes/docs/linting.md
+++ b/website/src/_includes/docs/linting.md
@@ -20,10 +20,10 @@ Rome stands out in the following ways:
 
 The [`rome check`](#rome-check) command is used to find problems in your project. This includes:
 
- - Dependency verification
- - Formatting
- - Linting
- - `package.json` validation
+- Dependency verification
+- Formatting
+- Linting
+- `package.json` validation
 
 We plan on expanding this list to include other checks such as dead code detection, license verification, type checking, and more.
 
@@ -77,8 +77,8 @@ To use the Rome linter we require usage of the Rome formatter. We offer powerful
 
 Notable formatting choices include:
 
- - Indentation: Hard tabs. [Improved accessibility](https://github.com/romefrontend/rome/issues/425) over two-spaced tabs.
- - Double string quotes. Consistent quote style across all supported languages.
+- Indentation: Hard tabs. [Improved accessibility](https://github.com/romefrontend/rome/issues/425) over two-spaced tabs.
+- Double string quotes. Consistent quote style across all supported languages.
 
 ### Applying Fixes
 
@@ -185,7 +185,7 @@ Get the most out of Rome by integrating it with your editor. You will get diagno
 
 Rome implements the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) supported by [various editors](https://microsoft.github.io/language-server-protocol/implementors/tools/). We have official extensions available for:
 
-- [VSCode](- [VSCode](https://marketplace.visualstudio.com/items?itemName=rome.rome))
+- [VSCode](https://marketplace.visualstudio.com/items?itemName=rome.rome)
 
 Once an editor extension has been installed, the version of Rome in your project will be automatically found and used. As we improve Rome and add new functionality any changes will automatically work with your editor!
 

--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -2,9 +2,9 @@
 
 **Rome** needs to know how to find your project and what files it includes. To do this we require a project configuration file.
 
-Your configuration can be placed in a [few different locations](#supported-locations), but we recommend using a single `rome.rjson` file. This file is written using [RJSON](/docs/rjson) which is our flavor of JSON. It supports comments and has a simpler syntax.
+Your configuration can be placed in a [few different locations](#supported-locations), but we recommend using a single `rome.rjson` file. This file is written using [RJSON](#rome-json) which is our flavor of JSON. It supports comments and has a simpler syntax.
 
-All properties are **optional**, you can even have an empty config! We recommend using the [`rome config`](/docs/cli/commands/config) command to modify your configuration, this works with any of the supported config locations, and when editing RJSON will even retain comments.
+All properties are **optional**, you can even have an empty config! We recommend using the [`rome config`](#rome-config) command to modify your configuration, this works with any of the supported config locations, and when editing RJSON will even retain comments.
 
 We are deliberately lean with the supported configuration. We do not include options just for the sake of personalization. We aim to offer everything out of the box and only introduce configuration if absolutely necessary.
 
@@ -83,7 +83,7 @@ You can specify your project config in a few different places.
 
 This is the recommend location. It's the file we create when running `rome init`.
 
-It can contains Rome's flavor of JSON, [RJSON](/docs/rjson), that allows comments and simpler syntax.
+It can contains Rome's flavor of JSON, [RJSON](#rome-json), that allows comments and simpler syntax.
 
 ##### `.config/rome.json`
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes docs links that pointed to `/docs` (like https://romefrontend.dev/docs/rjson) while it should point to current document's IDs.

For example, you can go to https://romefrontend.dev/#project-configuration and click on **RJSON** or **`rome config`** to reproduce (404 page)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

![404](https://user-images.githubusercontent.com/8527573/89723173-30498580-d9c9-11ea-9f95-e9d132262afb.png)

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Even though I just changed `.md` files, I couldn't run tests because it has thrown errors, as you can see in #999 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
