### PR TITLE
Match license identifiers case-insensitively

### DIFF
--- a/internal/codec-spdx-license/index.ts
+++ b/internal/codec-spdx-license/index.ts
@@ -23,7 +23,7 @@ const idToLicense: Map<string, License> = new Map();
 const licenseNames: Array<string> = [];
 for (const license of data.licenses) {
 	licenseNames.push(license.licenseId);
-	idToLicense.set(license.licenseId, license);
+	idToLicense.set(license.licenseId.toLowerCase(), license);
 }
 
 export {licenseNames};
@@ -31,7 +31,7 @@ export {licenseNames};
 export {ExpressionNode as SPDXExpressionNode} from "./parse";
 
 export function getSPDXLicense(licenseId: string): undefined | License {
-	return idToLicense.get(licenseId);
+	return idToLicense.get(licenseId.toLowerCase());
 }
 
 export {default as parseSPDXLicense} from "./parse";

--- a/internal/codec-spdx-license/parse.ts
+++ b/internal/codec-spdx-license/parse.ts
@@ -170,7 +170,7 @@ const createSPDXLicenseParser = createParser((ParserCore) =>
 			return {
 				type: "License",
 				loc: this.finishLoc(startPos),
-				id,
+				id: licenseInfo.licenseId,
 				exception,
 				plus,
 			};

--- a/internal/diagnostics/descriptions/parsers/spdx.ts
+++ b/internal/diagnostics/descriptions/parsers/spdx.ts
@@ -7,7 +7,7 @@ export const spdx = createDiagnosticsCategory({
 	UNKNOWN_LICENSE: (id: string, knownLicenses: Array<string>) => ({
 		message: markup`Unknown license <emphasis>${id}</emphasis>`,
 		advice: [
-			...buildSuggestionAdvice(id, knownLicenses),
+			...buildSuggestionAdvice(id, knownLicenses, { ignoreCase: true }),
 			{
 				type: "log",
 				category: "info",

--- a/internal/diagnostics/descriptions/parsers/spdx.ts
+++ b/internal/diagnostics/descriptions/parsers/spdx.ts
@@ -7,7 +7,7 @@ export const spdx = createDiagnosticsCategory({
 	UNKNOWN_LICENSE: (id: string, knownLicenses: Array<string>) => ({
 		message: markup`Unknown license <emphasis>${id}</emphasis>`,
 		advice: [
-			...buildSuggestionAdvice(id, knownLicenses, { ignoreCase: true }),
+			...buildSuggestionAdvice(id, knownLicenses, {ignoreCase: true}),
 			{
 				type: "log",
 				category: "info",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary
License identifiers are case insensitive, per:
https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/#case-sensitivity

## Test Plan

This package uses uppercase "APACHE-2.0", for example:
https://github.com/invertase/cluster-key-slot/blob/579d4a5f11cd3f63092286474a993350d6c7ca6d/package.json#L46

Depending on that package gave these results.

Before:
```
  ✖ Unknown license APACHE-2.0

    44 │     "url": "http://github.com/Salakar/"
    45 │   },
  > 46 │   "license": "APACHE-2.0",
       │               ^^^^^^^^^^
    47 │   "bugs": {
    48 │     "url": "https://github.com/Salakar/cluster-key-slot/issues"

  ℹ Did you mean APSL-2.0?

  - APACHE-2.0
  + APSL-2.0
```

After:
Pages and pages of JS lint output :)