### PR TITLE
[projectManager] Warn when multiple configs

### DIFF
--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -20,6 +20,7 @@ import {
 	Diagnostics,
 	DiagnosticsProcessor,
 	catchDiagnostics,
+	descriptions,
 } from "@internal/diagnostics";
 import {EventQueue} from "@internal/events";
 import {consumeJSON} from "@internal/codec-json";
@@ -932,6 +933,15 @@ export default class MemoryFileSystem {
 			dirname.getBasename() === PROJECT_CONFIG_DIRECTORY &&
 			PROJECT_CONFIG_FILENAMES.includes(basename)
 		) {
+			if (projectManager.hasLoadedProjectDirectory(dirname.getParent())) {
+				opts.diagnostics.addDiagnostic({
+					description: descriptions.PROJECT_MANAGER.MULTIPLE_CONFIGS,
+					location: {
+						filename: path.join(),
+					},
+				});
+			}
+
 			await projectManager.addDiskProject({
 				// Get the directory above .config
 				projectDirectory: dirname.getParent(),

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -852,6 +852,7 @@ export default class ProjectManager {
 
 		// If not then let's access the file system and try to find one
 		for (const dir of parentDirectories.slice().reverse()) {
+			let foundProjectDirectory = false;
 			// Check for dedicated project configs
 			for (const configFilename of PROJECT_CONFIG_FILENAMES) {
 				// Check in root
@@ -859,16 +860,25 @@ export default class ProjectManager {
 
 				const hasProject = await this.server.memoryFs.existsHard(configPath);
 				if (hasProject) {
+					if (foundProjectDirectory) {
+						throw createSingleDiagnosticError({
+							description: descriptions.PROJECT_MANAGER.MULTIPLE_CONFIGS,
+							location: {
+								filename: configPath.join(),
+							},
+						});
+					}
+					foundProjectDirectory = true;
 					if (this.isLoadingBannedProjectPath(dir, configPath, processor)) {
 						// Would have emitted a diagnostic
 						return;
 					}
-
-					await this.server.memoryFs.watch(dir);
-					return this.assertProjectExisting(cwd);
 				}
 			}
-
+			if (foundProjectDirectory) {
+				await this.server.memoryFs.watch(dir);
+				return this.assertProjectExisting(cwd);
+			}
 			// Check for package.json
 			const packagePath = dir.append("package.json");
 			if (await this.server.memoryFs.existsHard(packagePath)) {

--- a/internal/diagnostics/categories.ts
+++ b/internal/diagnostics/categories.ts
@@ -48,6 +48,7 @@ export type DiagnosticCategory =
 	| "parse/url/query"
 	| "parse/vscodeTheme"
 	| "projectManager/sensitiveDirectory"
+	| "projectManager/multipleConfigFiles"
 	| "projectManager/typoConfigFilename"
 	| "projectManager/misplacedConfig"
 	| "projectManager/missing"

--- a/internal/diagnostics/descriptions/projectManager.ts
+++ b/internal/diagnostics/descriptions/projectManager.ts
@@ -44,6 +44,17 @@ export const projectManager = createDiagnosticsCategory({
 			},
 		],
 	}),
+	MULTIPLE_CONFIGS: {
+		category: "projectManager/multipleConfigFiles",
+		message: markup`Multiple config files were found`,
+		advice: [
+			{
+				type: "log",
+				category: "info",
+				text: markup`There should be a single config file. Remove those that are unnecessary.`,
+			},
+		],
+	},
 	NOT_FOUND: {
 		category: "projectManager/missing",
 		message: markup`Couldn't find a project`,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #979 
 
I don't know if the **diagnostic message** is correct for what we want to display to the user.
Maybe we could do something similar to the `DUPLICATE_PACKAGE` diagnostic by telling the user **which files are in conflict**.

Like so:
<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/89919938-28bdf280-dbfc-11ea-89c0-850ce8a4953e.png" width="700">
</p>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

- Create a new Rome project with `rome init`.
- Add a new config file `.config/rome.json`.
- Run any rome command (e.g `rome check`)
- It should find the following problem

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/89917661-59e8f380-dbf9-11ea-9b13-1764ba3e4b85.png" width="500">
</p>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
