### PR TITLE
fix: subcommand description construction in fish shell completion

### DIFF
--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -27,7 +27,13 @@ import {
 	createUnknownFilePath,
 } from "@internal/path";
 import {Dict} from "@internal/typescript-helpers";
-import {AnyMarkups, StaticMarkup, concatMarkup, markup} from "@internal/markup";
+import {
+	AnyMarkups,
+	StaticMarkup,
+	concatMarkup,
+	markup,
+	readMarkup,
+} from "@internal/markup";
 import {
 	Diagnostic,
 	DiagnosticsError,
@@ -783,7 +789,13 @@ export default class Parser<T> {
 
 		// add command completions
 		for (let [subcmd, meta] of this.commands.entries()) {
-			script += `${scriptPre} -n '__fish_use_subcommand' -a '${subcmd}' -d '${meta.description}'\n`;
+			// add command description if exists
+			let description = "";
+			if (meta.description) {
+				description += ` -d '${readMarkup(meta.description)}'`;
+			}
+
+			script += `${scriptPre} -n '__fish_use_subcommand' -a '${subcmd}'${description}\n`;
 		}
 
 		// add flag completions


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`rome --log-shell-completions fish` prints the fish shell completion, but the output includes the meaningless subcommand description as below.

```console
> rome --log-shell-completions fish
complete -c rome -f
complete -c rome -n '__fish_use_subcommand' -a 'start' -d '[object Object]'
complete -c rome -n '__fish_use_subcommand' -a 'develop' -d '[object Object]'
complete -c rome -n '__fish_use_subcommand' -a 'stop' -d '[object Object]'
...
```

<img width="1275" alt="fish shell completion is meaningless" src="https://user-images.githubusercontent.com/7839872/89958157-2bf4c500-dc74-11ea-9f1c-eb8e0dd6ab64.png">


This PR makes the output meaningful.

```console
> rome --log-shell-completions fish
complete -c rome -f
complete -c rome -n '__fish_use_subcommand' -a 'start' -d 'start daemon (if none running)'
complete -c rome -n '__fish_use_subcommand' -a 'develop' -d 'TODO'
complete -c rome -n '__fish_use_subcommand' -a 'stop' -d 'stop a running daemon if one exists'
...
```

<img width="1323" alt="fish shell completion is meaningful" src="https://user-images.githubusercontent.com/7839872/89958197-4890fd00-dc74-11ea-82e2-6f821874af56.png">


<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
To fix https://github.com/romefrontend/rome/issues/1035

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Run `./rome --log-shell-completions fish`