### PR TITLE
Test cases for js-ast-utils/is-binary

### DIFF
--- a/internal/js-ast-utils/isBinary.test.ts
+++ b/internal/js-ast-utils/isBinary.test.ts
@@ -3,7 +3,7 @@ import {isBinary} from "./isBinary";
 import {parseJS} from "@internal/js-parser";
 import {jsExpressionStatement} from "@internal/ast";
 
-function binaryExpressionHelper(input: string) {
+function binaryExpressionHelper(input: string): boolean {
 	const node = jsExpressionStatement.assert(
 		parseJS({
 			path: "unknown",
@@ -15,18 +15,28 @@ function binaryExpressionHelper(input: string) {
 }
 
 test(
-	"isBinary",
+	"returns true for binary expressions",
 	(t) => {
 		t.true(binaryExpressionHelper("2+2;"));
 		t.true(binaryExpressionHelper("variableToReference * 10;"));
 		t.true(binaryExpressionHelper("100 / constantDeclared;"));
 		t.true(binaryExpressionHelper("100 << 2;"));
 		t.true(binaryExpressionHelper("listlike instanceof array;"));
+	},
+);
 
+test(
+	"returns true for logical expressions",
+	(t) => {
 		t.true(binaryExpressionHelper("true && false;"));
 		t.true(binaryExpressionHelper("identifierLookup || true;"));
 		t.true(binaryExpressionHelper("nullishValue ?? defaultArgument;"));
+	},
+);
 
+test(
+	"returns false if neither binary nor logical expression",
+	(t) => {
 		t.false(binaryExpressionHelper("[list, of, values];"));
 		t.false(binaryExpressionHelper("-1;"));
 		t.false(binaryExpressionHelper("!true;"));

--- a/internal/js-ast-utils/isBinary.test.ts
+++ b/internal/js-ast-utils/isBinary.test.ts
@@ -1,20 +1,15 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import {test} from "rome";
 import {isBinary} from "./isBinary";
 import {parseJS} from "@internal/js-parser";
-import {JSExpressionStatement} from "@internal/ast";
+import {jsExpressionStatement} from "@internal/ast";
 
 function binaryExpressionHelper(input: string) {
-	const node = (parseJS({
-		path: "unknown",
-		input,
-	}).body[0] as JSExpressionStatement);
+	const node = jsExpressionStatement.assert(
+		parseJS({
+			path: "unknown",
+			input,
+		}).body[0],
+	);
 
 	return isBinary(node.expression);
 }
@@ -22,22 +17,18 @@ function binaryExpressionHelper(input: string) {
 test(
 	"isBinary",
 	(t) => {
-		t.inlineSnapshot(binaryExpressionHelper("2+2;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("variableToReference * 10;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("100 / constantDeclared;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("100 << 2;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("listlike instanceof array;"), true);
+		t.true(binaryExpressionHelper("2+2;"));
+		t.true(binaryExpressionHelper("variableToReference * 10;"));
+		t.true(binaryExpressionHelper("100 / constantDeclared;"));
+		t.true(binaryExpressionHelper("100 << 2;"));
+		t.true(binaryExpressionHelper("listlike instanceof array;"));
 
-		t.inlineSnapshot(binaryExpressionHelper("true && false;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("identifierLookup || true;"), true);
-		t.inlineSnapshot(binaryExpressionHelper("identifierLookup || true;"), true);
-		t.inlineSnapshot(
-			binaryExpressionHelper("nullishValue ?? defaultArgument;"),
-			true,
-		);
+		t.true(binaryExpressionHelper("true && false;"));
+		t.true(binaryExpressionHelper("identifierLookup || true;"));
+		t.true(binaryExpressionHelper("nullishValue ?? defaultArgument;"));
 
-		t.inlineSnapshot(binaryExpressionHelper("[list, of, values];"), false);
-		t.inlineSnapshot(binaryExpressionHelper("-1;"), false);
-		t.inlineSnapshot(binaryExpressionHelper("!true;"), false);
+		t.false(binaryExpressionHelper("[list, of, values];"));
+		t.false(binaryExpressionHelper("-1;"));
+		t.false(binaryExpressionHelper("!true;"));
 	},
 );

--- a/internal/js-ast-utils/isBinary.test.ts
+++ b/internal/js-ast-utils/isBinary.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {test} from "rome";
+import {isBinary} from "./isBinary";
+import {parseJS} from "@internal/js-parser";
+import {JSExpressionStatement} from "@internal/ast";
+
+function binaryExpressionHelper(input: string) {
+	const node = (parseJS({
+		path: "unknown",
+		input,
+	}).body[0] as JSExpressionStatement);
+
+	return isBinary(node.expression);
+}
+
+test(
+	"isBinary",
+	(t) => {
+		t.inlineSnapshot(binaryExpressionHelper("2+2;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("variableToReference * 10;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("100 / constantDeclared;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("100 << 2;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("listlike instanceof array;"), true);
+
+		t.inlineSnapshot(binaryExpressionHelper("true && false;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("identifierLookup || true;"), true);
+		t.inlineSnapshot(binaryExpressionHelper("identifierLookup || true;"), true);
+		t.inlineSnapshot(
+			binaryExpressionHelper("nullishValue ?? defaultArgument;"),
+			true,
+		);
+
+		t.inlineSnapshot(binaryExpressionHelper("[list, of, values];"), false);
+		t.inlineSnapshot(binaryExpressionHelper("-1;"), false);
+		t.inlineSnapshot(binaryExpressionHelper("!true;"), false);
+	},
+);


### PR DESCRIPTION
Part of #1023 


## Summary 

This PR adds test cases for the `isBinary` utility checking binary and non-binary expressions (unary, arrays). 

Note: I wasn't sure if the copyright header was needed but I saw it in other tests I used as samples, so I kept it. Please let me know if it needs to change.

## Test Plan

It runs and passes with  `./rome test internal/js-ast-utils/isBinary.test.ts`

No changes to other tests, so `./rome test` still passes (I've verified)