### PR TITLE
Add tests for codec-source-map/ArraySet

### DIFF
--- a/internal/codec-source-map/ArraySet.test.ts
+++ b/internal/codec-source-map/ArraySet.test.ts
@@ -1,0 +1,41 @@
+import {test} from "rome";
+import ArraySet from "./ArraySet";
+
+test(
+	"strings added to the set exist",
+	(t) => {
+		const set = new ArraySet();
+		set.add("test string");
+		t.true(set.indexOf("test string") === 0);
+	},
+);
+
+test(
+	"indexOf returns index of first match when allowing duplicates ",
+	(t) => {
+		const set = new ArraySet();
+		set.add("test string");
+		set.add("in the middle");
+		set.add("test string", true);
+		t.true(set.indexOf("test string") === 0);
+	},
+);
+
+test(
+	"indexOf throws when a string is not present",
+	(t) => {
+		const set = new ArraySet();
+		t.throws(() => void set.indexOf("missing string"));
+	},
+);
+
+test(
+	"toArray provides a new copy of the underlying data",
+	(t) => {
+		const set = new ArraySet();
+		set.add("test string");
+		const array = set.toArray();
+		array.push("missing string");
+		t.throws(() => void set.indexOf("missing string"));
+	},
+);


### PR DESCRIPTION
## Summary
Part of #1023 

I'm happy to close this, given @sebmck's comment [here](https://github.com/romefrontend/rome/issues/1023#issuecomment-673688408) - seems like this is largely around the ast/isX methods, but just want to make sure.

This just adds tests for asserts around indexOf, since adding to sets is relatively known.

## Test Plan

` ./rome test internal/codec-source-map/ArraySet.test.ts`

Specifically, I tested that sets add to the underlying array, that adding duplicates would result in `indexOf` only knowing the first element, and errors thrown on indexOf in certain conditions.