### PR TITLE
test: added tests for isJsxElement in ast-js-utils

### DIFF
--- a/internal/js-ast-utils/isJSXElement.test.ts
+++ b/internal/js-ast-utils/isJSXElement.test.ts
@@ -1,0 +1,74 @@
+import {test} from "rome";
+import {AnyNode, jsExpressionStatement} from "@internal/ast";
+import {parseJS} from "@internal/js-parser";
+import {isJSXElement} from "./isJSXElement";
+import {createBuilder} from "@internal/ast/utils";
+
+function helper(input: string): AnyNode {
+	const node = jsExpressionStatement.assert(
+		parseJS({
+			input,
+			path: "unknown",
+		}).body[0],
+	);
+	return node.expression;
+}
+
+test(
+	"returns true for jsx elements",
+	(t) => {
+		t.true(isJSXElement(helper("<div>a</div>"), "div"));
+		t.true(
+			isJSXElement(
+				createBuilder(
+					"JSXElement",
+					{
+						bindingKeys: {},
+						visitorKeys: {
+							name: true,
+							typeArguments: true,
+							attributes: true,
+							children: true,
+						},
+					},
+				).create(helper("<ul></ul>")),
+				"ul",
+			),
+		);
+		t.true(isJSXElement(helper("<ul>text</ul>"), "ul"));
+		t.true(isJSXElement(helper(`<span id="key">{var}</span>`), "span"));
+		t.true(isJSXElement(helper("<CustomComp></CustomComp>"), "CustomComp"));
+		t.true(isJSXElement(helper("<component>"), "component"));
+	},
+);
+
+test(
+	"returns false for non-jsx elements",
+	(t) => {
+		t.false(isJSXElement(helper("2+3"), "div"));
+		t.false(isJSXElement(helper("someValue / 4"), "ul"));
+		t.false(isJSXElement(helper("2;"), "li"));
+		t.false(isJSXElement(helper("true"), "span"));
+		t.false(
+			isJSXElement(
+				createBuilder(
+					"jsIfStatement",
+					{
+						bindingKeys: {},
+						visitorKeys: {test: true, consequent: true, alternate: true},
+					},
+				).create({}),
+				"li",
+			),
+		);
+	},
+);
+
+test(
+	"returns false when there is name mismatch",
+	(t) => {
+		t.false(isJSXElement(helper("<div></div>"), "ul"));
+		t.false(isJSXElement(helper("<span></span>"), "img"));
+		t.false(isJSXElement(helper("<test>"), "otherTest"));
+	},
+);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary
       
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
part of  #1023 
added tests for `isJSXElement` function in `js-ast-utils`
<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
`./rome test` --all tests passed 