### PR TITLE
chore: Fix clearBuffer name in ServerRequest

### DIFF
--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -920,7 +920,7 @@ export default class ServerRequest {
 		this.checkCancelled();
 
 		await this.wrapRequestDiagnostic(
-			"updateBuffer",
+			"clearBuffer",
 			path,
 			async (bridge, ref) => {
 				await bridge.clearBuffer.call({ref});


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This fixes the `clearBuffer` method name used in logs and markers. Looks like this was just a copy/paste mistake.
