### PR TITLE
Rename UnknownFilePath and URLFilePath to UnknownPath and URLPath. Fix for good empty segment reduction.

### DIFF
--- a/internal/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/internal/cli-diagnostics/DiagnosticsPrinter.ts
@@ -35,10 +35,10 @@ import {default as errorBanner} from "./banners/error.json";
 import {
 	AbsoluteFilePath,
 	CWD_PATH,
-	UnknownFilePath,
-	UnknownFilePathMap,
-	UnknownFilePathSet,
-	createUnknownFilePath,
+	UnknownPath,
+	UnknownPathMap,
+	UnknownPathSet,
+	createUnknownPath,
 } from "@internal/path";
 import {Number0, Number1, ob1Get0, ob1Get1} from "@internal/ob1";
 import {exists, lstat, readFileText} from "@internal/fs";
@@ -108,14 +108,14 @@ export const DEFAULT_PRINTER_FLAGS: DiagnosticsPrinterFlags = {
 // Dependency that may not be included in the output diagnostic but whose changes may effect the validity of this one
 type ChangeFileDependency = {
 	type: "change";
-	path: UnknownFilePath;
+	path: UnknownPath;
 	mtime: undefined | number;
 };
 
 // Dependency that will have a code frame in the output diagnostic
 type ReferenceFileDependency = {
 	type: "reference";
-	path: UnknownFilePath;
+	path: UnknownPath;
 	mtime: undefined | number;
 	sourceTypeJS: undefined | DiagnosticSourceType;
 	language: undefined | DiagnosticLanguage;
@@ -128,12 +128,12 @@ function hasFrame(loc: DiagnosticLocation): boolean {
 	return loc.start !== undefined && loc.end !== undefined;
 }
 
-export type DiagnosticsPrinterFileSources = UnknownFilePathMap<{
+export type DiagnosticsPrinterFileSources = UnknownPathMap<{
 	sourceText: string;
 	lines: ToLines;
 }>;
 
-export type DiagnosticsPrinterFileMtimes = UnknownFilePathMap<number>;
+export type DiagnosticsPrinterFileMtimes = UnknownPathMap<number>;
 
 export default class DiagnosticsPrinter extends Error {
 	constructor(opts: DiagnosticsPrinterOptions) {
@@ -159,9 +159,9 @@ export default class DiagnosticsPrinter extends Error {
 		this.truncatedCount = 0;
 
 		this.hasTruncatedDiagnostics = false;
-		this.missingFileSources = new UnknownFilePathSet();
-		this.fileSources = new UnknownFilePathMap();
-		this.fileMtimes = new UnknownFilePathMap();
+		this.missingFileSources = new UnknownPathSet();
+		this.fileSources = new UnknownPathMap();
+		this.fileMtimes = new UnknownPathMap();
 		this.onFooterPrintCallbacks = [];
 	}
 
@@ -177,7 +177,7 @@ export default class DiagnosticsPrinter extends Error {
 	private cwd: AbsoluteFilePath;
 	private fileReaders: Array<DiagnosticsFileReaders>;
 	private hasTruncatedDiagnostics: boolean;
-	private missingFileSources: UnknownFilePathSet;
+	private missingFileSources: UnknownPathSet;
 	private fileSources: DiagnosticsPrinterFileSources;
 	private fileMtimes: DiagnosticsPrinterFileMtimes;
 
@@ -186,13 +186,13 @@ export default class DiagnosticsPrinter extends Error {
 	private filteredCount: number;
 	private truncatedCount: number;
 
-	public createFilePath(filename: string): UnknownFilePath {
+	public createFilePath(filename: string): UnknownPath {
 		const {normalizePosition} = this.reporter.markupOptions;
 
 		if (normalizePosition === undefined) {
-			return createUnknownFilePath(filename);
+			return createUnknownPath(filename);
 		} else {
-			return createUnknownFilePath(
+			return createUnknownPath(
 				normalizePosition(filename, undefined, undefined).filename,
 			);
 		}
@@ -381,7 +381,7 @@ export default class DiagnosticsPrinter extends Error {
 			}
 		}
 
-		const depsMap: UnknownFilePathMap<FileDependency> = new UnknownFilePathMap();
+		const depsMap: UnknownPathMap<FileDependency> = new UnknownPathMap();
 
 		// Remove non-absolute filenames and normalize sourceType and language for conflicts
 		for (const dep of deps) {
@@ -489,8 +489,8 @@ export default class DiagnosticsPrinter extends Error {
 		reporter.redirectOutToErr(restoreRedirect);
 	}
 
-	public getOutdatedFiles(diag: Diagnostic): UnknownFilePathSet {
-		let outdatedFiles: UnknownFilePathSet = new UnknownFilePathSet();
+	public getOutdatedFiles(diag: Diagnostic): UnknownPathSet {
+		let outdatedFiles: UnknownPathSet = new UnknownPathSet();
 		for (const {
 			path,
 			mtime: expectedMtime,
@@ -519,7 +519,7 @@ export default class DiagnosticsPrinter extends Error {
 				const parts = [];
 
 				if (filename !== undefined) {
-					const path = createUnknownFilePath(filename);
+					const path = createUnknownPath(filename);
 
 					if (path.isAbsolute() && path.isRelativeTo(this.cwd)) {
 						parts.push(`file=${this.cwd.relative(path).join()}`);

--- a/internal/cli-diagnostics/printAdvice.ts
+++ b/internal/cli-diagnostics/printAdvice.ts
@@ -37,7 +37,7 @@ import {
 } from "@internal/markup";
 import {DiagnosticsPrinterFlags} from "./types";
 import DiagnosticsPrinter, {DiagnosticsPrinterFileSources} from "./DiagnosticsPrinter";
-import {UnknownFilePathSet, createUnknownFilePath} from "@internal/path";
+import {UnknownPathSet, createUnknownPath} from "@internal/path";
 import {MAX_CODE_LENGTH, MAX_CODE_LINES, MAX_LOG_LENGTH} from "./constants";
 import {Diffs, diffConstants} from "@internal/string-diff";
 import {removeCarriageReturn} from "@internal/string-utils";
@@ -47,7 +47,7 @@ import {inferDiagnosticLanguageFromFilename} from "@internal/core/common/file-ha
 type AdvicePrintOptions = {
 	printer: DiagnosticsPrinter;
 	flags: DiagnosticsPrinterFlags;
-	missingFileSources: UnknownFilePathSet;
+	missingFileSources: UnknownPathSet;
 	fileSources: DiagnosticsPrinterFileSources;
 	reporter: Reporter;
 	diagnostic: Diagnostic;
@@ -314,7 +314,7 @@ function printCode(
 		truncateLines: MAX_CODE_LINES,
 		lines: toLines({
 			input: code,
-			path: createUnknownFilePath("inline"),
+			path: createUnknownPath("inline"),
 			sourceTypeJS: item.sourceTypeJS,
 			language: item.language,
 			highlight: opts.printer.shouldHighlight(),
@@ -345,7 +345,7 @@ function printFrame(
 	let {sourceText} = item.location;
 	const path =
 		filename === undefined
-			? createUnknownFilePath("unknown")
+			? createUnknownPath("unknown")
 			: opts.printer.createFilePath(filename);
 
 	let lines: ToLines = [];
@@ -479,12 +479,15 @@ function printStacktrace(
 
 			reporter.log(concatMarkup(logParts, markup` `));
 
-			if (
-				shownCodeFrames < 2 &&
+			// A code frame will always be displayed if it's been marked as important on the stackframe advice or if it
+			// refers to the diagnostic
+			const isImportantStackFrame = filename !== undefined && (filename === diagnostic.location.filename || (item.importantFilenames !== undefined && item.importantFilenames.includes(filename)));
+			const shouldShowCodeFrame = isImportantStackFrame || shownCodeFrames < 2;
+
+			if (shouldShowCodeFrame &&
 				filename !== undefined &&
 				line !== undefined &&
-				column !== undefined
-			) {
+				column !== undefined) {
 				const pos: Position = {
 					line,
 					column,
@@ -507,7 +510,7 @@ function printStacktrace(
 						reporter,
 					},
 				);
-				if (frame.printed) {
+				if (frame.printed && !isImportantStackFrame) {
 					shownCodeFrames++;
 				}
 			}

--- a/internal/cli-diagnostics/printAdvice.ts
+++ b/internal/cli-diagnostics/printAdvice.ts
@@ -481,13 +481,19 @@ function printStacktrace(
 
 			// A code frame will always be displayed if it's been marked as important on the stackframe advice or if it
 			// refers to the diagnostic
-			const isImportantStackFrame = filename !== undefined && (filename === diagnostic.location.filename || (item.importantFilenames !== undefined && item.importantFilenames.includes(filename)));
+			const isImportantStackFrame =
+				filename !== undefined &&
+				(filename === diagnostic.location.filename ||
+				(item.importantFilenames !== undefined &&
+				item.importantFilenames.includes(filename)));
 			const shouldShowCodeFrame = isImportantStackFrame || shownCodeFrames < 2;
 
-			if (shouldShowCodeFrame &&
+			if (
+				shouldShowCodeFrame &&
 				filename !== undefined &&
 				line !== undefined &&
-				column !== undefined) {
+				column !== undefined
+			) {
 				const pos: Position = {
 					line,
 					column,

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -21,11 +21,7 @@ import {
 	toCamelCase,
 	toKebabCase,
 } from "@internal/string-utils";
-import {
-	AbsoluteFilePath,
-	HOME_PATH,
-	createUnknownPath,
-} from "@internal/path";
+import {AbsoluteFilePath, HOME_PATH, createUnknownPath} from "@internal/path";
 import {Dict} from "@internal/typescript-helpers";
 import {
 	AnyMarkups,

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -24,7 +24,7 @@ import {
 import {
 	AbsoluteFilePath,
 	HOME_PATH,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 import {Dict} from "@internal/typescript-helpers";
 import {
@@ -240,7 +240,7 @@ export default class Parser<T> {
 		}
 
 		const consumer = consume({
-			filePath: createUnknownFilePath("argv"),
+			filePath: createUnknownPath("argv"),
 			value: flags,
 			onDefinition: (def, valueConsumer) => {
 				const key = def.objectPath.join(".");

--- a/internal/codec-binary-serial/RSERBufferAssembler.ts
+++ b/internal/codec-binary-serial/RSERBufferAssembler.ts
@@ -25,10 +25,10 @@ import {
 	RelativeFilePath,
 	RelativeFilePathMap,
 	RelativeFilePathSet,
-	URLFilePath,
-	UnknownFilePath,
-	UnknownFilePathMap,
-	UnknownFilePathSet,
+	URLPath,
+	UnknownPath,
+	UnknownPathMap,
+	UnknownPathSet,
 } from "@internal/path";
 import {getErrorStructure} from "@internal/v8";
 import {pretty} from "@internal/pretty-format";
@@ -254,10 +254,10 @@ export default class RSERBufferAssembler {
 		this.seenObjects.add(val);
 
 		if (
-			val instanceof UnknownFilePath ||
+			val instanceof UnknownPath ||
 			val instanceof RelativeFilePath ||
 			val instanceof AbsoluteFilePath ||
-			val instanceof URLFilePath
+			val instanceof URLPath
 		) {
 			return this.encodeFilePath(val);
 		}
@@ -281,7 +281,7 @@ export default class RSERBufferAssembler {
 		if (
 			val instanceof RelativeFilePathMap ||
 			val instanceof AbsoluteFilePathMap ||
-			val instanceof UnknownFilePathMap
+			val instanceof UnknownPathMap
 		) {
 			return this.encodeFilePathMap(val);
 		}
@@ -289,7 +289,7 @@ export default class RSERBufferAssembler {
 		if (
 			val instanceof RelativeFilePathSet ||
 			val instanceof AbsoluteFilePathSet ||
-			val instanceof UnknownFilePathSet
+			val instanceof UnknownPathSet
 		) {
 			return this.encodeFilePathSet(val);
 		}

--- a/internal/codec-binary-serial/codes.ts
+++ b/internal/codec-binary-serial/codes.ts
@@ -7,14 +7,14 @@ import {
 	RelativeFilePath,
 	RelativeFilePathMap,
 	RelativeFilePathSet,
-	URLFilePath,
-	UnknownFilePath,
-	UnknownFilePathMap,
-	UnknownFilePathSet,
+	URLPath,
+	UnknownPath,
+	UnknownPathMap,
+	UnknownPathSet,
 	createAbsoluteFilePath,
 	createRelativeFilePath,
-	createURLFilePath,
-	createUnknownFilePath,
+	createURLPath,
+	createUnknownPath,
 } from "@internal/path";
 import {AnyRSERFilePathMap} from "@internal/codec-binary-serial/types";
 
@@ -191,7 +191,7 @@ export function filePathMapToCode(map: AnyRSERFilePathMap): FILE_CODES {
 		return FILE_CODES.RELATIVE;
 	} else if (map instanceof AbsoluteFilePathMap) {
 		return FILE_CODES.ABSOLUTE;
-	} else if (map instanceof UnknownFilePathMap) {
+	} else if (map instanceof UnknownPathMap) {
 		return FILE_CODES.UNKNOWN;
 	} else {
 		throw new Error("Unknown FilePath type");
@@ -203,7 +203,7 @@ export function filePathSetToCode(set: AnyFilePathSet): FILE_CODES {
 		return FILE_CODES.RELATIVE;
 	} else if (set instanceof AbsoluteFilePathSet) {
 		return FILE_CODES.ABSOLUTE;
-	} else if (set instanceof UnknownFilePathSet) {
+	} else if (set instanceof UnknownPathSet) {
 		return FILE_CODES.UNKNOWN;
 	} else {
 		throw new Error("Unknown FilePath type");
@@ -215,9 +215,9 @@ export function filePathToCode(path: AnyFilePath): FILE_CODES {
 		return FILE_CODES.RELATIVE;
 	} else if (path instanceof AbsoluteFilePath) {
 		return FILE_CODES.ABSOLUTE;
-	} else if (path instanceof UnknownFilePath) {
+	} else if (path instanceof UnknownPath) {
 		return FILE_CODES.UNKNOWN;
-	} else if (path instanceof URLFilePath) {
+	} else if (path instanceof URLPath) {
 		return FILE_CODES.URL;
 	} else {
 		throw new Error("Unknown FilePath type");
@@ -236,17 +236,17 @@ export function filePathFromCode(
 			return createAbsoluteFilePath(filename);
 
 		case FILE_CODES.URL:
-			return createURLFilePath(filename);
+			return createURLPath(filename);
 
 		case FILE_CODES.UNKNOWN:
-			return createUnknownFilePath(filename);
+			return createUnknownPath(filename);
 	}
 }
 
 export function filePathMapFromCode(code: FILE_CODES): AnyRSERFilePathMap {
 	switch (code) {
 		case FILE_CODES.UNKNOWN:
-			return new UnknownFilePathMap();
+			return new UnknownPathMap();
 
 		case FILE_CODES.RELATIVE:
 			return new RelativeFilePathMap();
@@ -262,7 +262,7 @@ export function filePathMapFromCode(code: FILE_CODES): AnyRSERFilePathMap {
 export function filePathSetFromCode(code: FILE_CODES): AnyFilePathSet {
 	switch (code) {
 		case FILE_CODES.UNKNOWN:
-			return new UnknownFilePathSet();
+			return new UnknownPathSet();
 
 		case FILE_CODES.RELATIVE:
 			return new RelativeFilePathSet();

--- a/internal/codec-binary-serial/index.ts
+++ b/internal/codec-binary-serial/index.ts
@@ -15,7 +15,7 @@ export {
 	RSERObject,
 	RSERRelativeFilePathMap,
 	RSERSet,
-	RSERUnknownFilePathMap,
+	RSERUnknownPathMap,
 	RSERValue,
 } from "./types";
 

--- a/internal/codec-binary-serial/types.ts
+++ b/internal/codec-binary-serial/types.ts
@@ -3,7 +3,7 @@ import {
 	AnyFilePath,
 	AnyFilePathSet,
 	RelativeFilePathMap,
-	UnknownFilePathMap,
+	UnknownPathMap,
 } from "@internal/path";
 
 export type IntSize = 1 | 2 | 4 | 8;
@@ -33,9 +33,9 @@ export type RSERValue =
 export type AnyRSERFilePathMap =
 	| RSERAbsoluteFilePathMap
 	| RSERRelativeFilePathMap
-	| RSERUnknownFilePathMap;
+	| RSERUnknownPathMap;
 
-export type RSERUnknownFilePathMap = UnknownFilePathMap<RSERValue>;
+export type RSERUnknownPathMap = UnknownPathMap<RSERValue>;
 export type RSERAbsoluteFilePathMap = AbsoluteFilePathMap<RSERValue>;
 export type RSERRelativeFilePathMap = RelativeFilePathMap<RSERValue>;
 

--- a/internal/codec-js-manifest/dependencies.ts
+++ b/internal/codec-js-manifest/dependencies.ts
@@ -12,7 +12,7 @@ import {
 	stringifySemver,
 } from "@internal/codec-semver";
 import {tryParseWithOptionalOffsetPosition} from "@internal/parser-core";
-import {UnknownFilePath, createUnknownFilePath} from "@internal/path";
+import {UnknownPath, createUnknownPath} from "@internal/path";
 import {normalizeName} from "./name";
 import {ob1Add} from "@internal/ob1";
 import {descriptions} from "@internal/diagnostics";
@@ -297,13 +297,13 @@ const LINK_PREFIX = "link:";
 
 type LinkPattern = {
 	type: "link";
-	path: UnknownFilePath;
+	path: UnknownPath;
 };
 
 function parseLink(pattern: string): LinkPattern {
 	return {
 		type: "link",
-		path: createUnknownFilePath(pattern.slice(LINK_PREFIX.length)),
+		path: createUnknownPath(pattern.slice(LINK_PREFIX.length)),
 	};
 }
 
@@ -465,7 +465,7 @@ export function parseDependencyPattern(
 
 	if (
 		FILE_PREFIX_REGEX.test(pattern) ||
-		createUnknownFilePath(pattern).isAbsolute() ||
+		createUnknownPath(pattern).isAbsolute() ||
 		pattern.startsWith("file:")
 	) {
 		return parseFile(pattern);

--- a/internal/codec-json/parser.test.ts
+++ b/internal/codec-json/parser.test.ts
@@ -10,12 +10,12 @@ import {descriptions} from "@internal/diagnostics";
 import {parseJSON} from "@internal/codec-json";
 import {test} from "rome";
 import {ParserOptions} from "@internal/parser-core";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {readMarkup} from "@internal/markup";
 
 // These are just some very basic tests, most of it is already covered by test262-parse so most are redundant
 function parseExtJSON(opts: ParserOptions) {
-	return parseJSON({...opts, path: createUnknownFilePath("input.rjson")});
+	return parseJSON({...opts, path: createUnknownPath("input.rjson")});
 }
 
 test(

--- a/internal/codec-json/stringify.test.ts
+++ b/internal/codec-json/stringify.test.ts
@@ -12,13 +12,13 @@ import {
 } from "@internal/codec-json";
 import {test} from "rome";
 import {ParserOptions} from "@internal/parser-core";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {Dict} from "@internal/typescript-helpers";
 
 function consumeExtJSON(opts: ParserOptions) {
 	return consumeJSONExtra({
 		...opts,
-		path: createUnknownFilePath("input.rjson"),
+		path: createUnknownPath("input.rjson"),
 	});
 }
 

--- a/internal/compiler/api/analyzeDependencies.test.ts
+++ b/internal/compiler/api/analyzeDependencies.test.ts
@@ -10,13 +10,13 @@ import {createDefaultProjectConfig} from "@internal/project";
 import {test} from "rome";
 import {parseJS} from "@internal/js-parser";
 import {ConstJSSourceType} from "@internal/ast";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {dedent} from "@internal/string-utils";
 
 async function testAnalyzeDeps(input: string, sourceType: ConstJSSourceType) {
 	return await analyzeDependencies({
 		options: {},
-		ast: parseJS({input, sourceType, path: createUnknownFilePath("unknown")}),
+		ast: parseJS({input, sourceType, path: createUnknownPath("unknown")}),
 		sourceText: input,
 		project: {
 			directory: undefined,

--- a/internal/compiler/lib/CompilerContext.ts
+++ b/internal/compiler/lib/CompilerContext.ts
@@ -30,7 +30,7 @@ import {
 import Record from "./Record";
 import {RootScope} from "../scope/Scope";
 import {reduceNode} from "../methods/reduce";
-import {UnknownFilePath, createUnknownFilePath} from "@internal/path";
+import {UnknownPath, createUnknownPath} from "@internal/path";
 import {
 	AnyVisitor,
 	LintCompilerOptionsDecision,
@@ -104,7 +104,7 @@ export default class CompilerContext {
 		this.records = [];
 
 		this.ast = ast;
-		this.path = createUnknownFilePath(ast.filename);
+		this.path = createUnknownPath(ast.filename);
 		this.filename = ast.filename;
 		this.displayFilename =
 			ref === undefined ? ast.filename : ref.relative.join();
@@ -132,7 +132,7 @@ export default class CompilerContext {
 	public displayFilename: string;
 	public filename: string;
 	private mtime: undefined | number;
-	public path: UnknownFilePath;
+	public path: UnknownPath;
 	public project: TransformProjectDefinition;
 	public language: DiagnosticLanguage;
 	private sourceTypeJS: undefined | ConstJSSourceType;

--- a/internal/compiler/lint/rules/js/useDefaultExportBasename.ts
+++ b/internal/compiler/lint/rules/js/useDefaultExportBasename.ts
@@ -12,7 +12,7 @@ import {
 	JSFunctionDeclaration,
 } from "@internal/ast";
 import {createVisitor, signals} from "@internal/compiler";
-import {UnknownFilePath} from "@internal/path";
+import {UnknownPath} from "@internal/path";
 import {renameBindings} from "@internal/js-ast-utils";
 import {descriptions} from "@internal/diagnostics";
 import {normalizeCamelCase} from "./useCamelCase";
@@ -27,7 +27,7 @@ function isValidDeclaration(
 }
 
 export function filenameToId(
-	path: UnknownFilePath,
+	path: UnknownPath,
 	capitalize: boolean,
 ): undefined | string {
 	let basename = path.getExtensionlessBasename();

--- a/internal/compiler/lint/rules/js/useDefaultImportBasename.ts
+++ b/internal/compiler/lint/rules/js/useDefaultImportBasename.ts
@@ -7,7 +7,7 @@
 
 import {createVisitor, signals} from "@internal/compiler";
 import {descriptions} from "@internal/diagnostics";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {filenameToId} from "./useDefaultExportBasename";
 
 export default createVisitor({
@@ -21,7 +21,7 @@ export default createVisitor({
 				return signals.retain;
 			}
 
-			const filePath = createUnknownFilePath(node.source.value);
+			const filePath = createUnknownPath(node.source.value);
 			const expectedName = filenameToId(filePath, false);
 			const expectedNameCapital = filenameToId(filePath, true);
 			if (expectedName === undefined || expectedNameCapital === undefined) {

--- a/internal/consume/Consumer.ts
+++ b/internal/consume/Consumer.ts
@@ -56,11 +56,11 @@ import {escapeJSString} from "@internal/string-escape";
 import {
 	AbsoluteFilePath,
 	RelativeFilePath,
-	URLFilePath,
-	UnknownFilePath,
+	URLPath,
+	UnknownPath,
 	createAbsoluteFilePath,
-	createURLFilePath,
-	createUnknownFilePath,
+	createURLPath,
+	createUnknownPath,
 } from "@internal/path";
 import {StaticMarkup, markup, readMarkup} from "@internal/markup";
 
@@ -96,7 +96,7 @@ export default class Consumer {
 		this.handleUnexpected = opts.handleUnexpectedDiagnostic;
 	}
 
-	public path: undefined | UnknownFilePath;
+	public path: undefined | UnknownPath;
 	public filename: undefined | string;
 
 	private declared: boolean;
@@ -1023,26 +1023,26 @@ export default class Consumer {
 		);
 	}
 
-	public asURLFilePath(def?: string): URLFilePath {
-		const path = this.asUnknownFilePath(def);
+	public asURLPath(def?: string): URLPath {
+		const path = this.asUnknownPath(def);
 		if (path.isURL()) {
 			return path.assertURL();
 		} else {
 			this.unexpected(descriptions.CONSUME.EXPECTED_URL);
-			return createURLFilePath("unknown://").append(...path.getSegments());
+			return createURLPath("unknown://").append(...path.getSegments());
 		}
 	}
 
-	public asURLFilePathOrVoid(): undefined | URLFilePath {
+	public asURLPathOrVoid(): undefined | URLPath {
 		if (this.exists()) {
-			return this.asURLFilePath();
+			return this.asURLPath();
 		} else {
 			this._declareOptionalFilePath();
 			return undefined;
 		}
 	}
 
-	public asUnknownFilePath(def?: string): UnknownFilePath {
+	public asUnknownPath(def?: string): UnknownPath {
 		this.declareDefinition(
 			{
 				type: "string",
@@ -1052,12 +1052,12 @@ export default class Consumer {
 			"path",
 		);
 
-		return createUnknownFilePath(this.asString(def));
+		return createUnknownPath(this.asString(def));
 	}
 
-	public asUnknownFilePathOrVoid(): undefined | UnknownFilePath {
+	public asUnknownPathOrVoid(): undefined | UnknownPath {
 		if (this.exists()) {
-			return this.asUnknownFilePath();
+			return this.asUnknownPath();
 		} else {
 			this._declareOptionalFilePath();
 			return undefined;
@@ -1068,7 +1068,7 @@ export default class Consumer {
 		def?: string,
 		cwd?: AbsoluteFilePath,
 	): AbsoluteFilePath {
-		const path = this.asUnknownFilePath(def);
+		const path = this.asUnknownPath(def);
 		if (path.isAbsolute()) {
 			return path.assertAbsolute();
 		} else if (cwd !== undefined && path.isRelative()) {
@@ -1091,7 +1091,7 @@ export default class Consumer {
 	}
 
 	public asRelativeFilePath(def?: string): RelativeFilePath {
-		const path = this.asUnknownFilePath(def);
+		const path = this.asUnknownPath(def);
 		if (path.isRelative()) {
 			return path.assertRelative();
 		} else {

--- a/internal/consume/types.ts
+++ b/internal/consume/types.ts
@@ -11,7 +11,7 @@ import {
 	DiagnosticLocation,
 } from "@internal/diagnostics";
 import Consumer from "./Consumer";
-import {UnknownFilePath} from "@internal/path";
+import {UnknownPath} from "@internal/path";
 import {StaticMarkup} from "@internal/markup";
 
 export type ConsumeKey = number | string;
@@ -82,7 +82,7 @@ export type ConsumerOptions = {
 	handleUnexpectedDiagnostic?: ConsumerHandleUnexpected;
 	onDefinition?: ConsumerOnDefinition;
 	propertyMetadata?: ConsumePropertyMetadata;
-	filePath?: UnknownFilePath;
+	filePath?: UnknownPath;
 	objectPath: ConsumePath;
 	context: ConsumeContext;
 	value: unknown;

--- a/internal/core/common/file-handlers/index.ts
+++ b/internal/core/common/file-handlers/index.ts
@@ -8,8 +8,8 @@
 import {ProjectConfig} from "@internal/project";
 import {
 	AnyFilePath,
-	UnknownFilePath,
-	createUnknownFilePath,
+	UnknownPath,
+	createUnknownPath,
 } from "@internal/path";
 import {ExtensionHandler} from "./types";
 import {
@@ -35,7 +35,7 @@ export type GetFileHandlerResult = {
 };
 
 export function inferDiagnosticLanguageFromFilename(
-	filename: undefined | UnknownFilePath | string,
+	filename: undefined | UnknownPath | string,
 	existing?: DiagnosticLanguage,
 ): DiagnosticLanguage {
 	if (existing !== undefined && existing !== "unknown") {
@@ -43,7 +43,7 @@ export function inferDiagnosticLanguageFromFilename(
 	}
 	if (filename !== undefined) {
 		const {handler} = getFileHandlerFromPath(
-			createUnknownFilePath(filename),
+			createUnknownPath(filename),
 			undefined,
 		);
 		if (handler !== undefined) {

--- a/internal/core/common/file-handlers/index.ts
+++ b/internal/core/common/file-handlers/index.ts
@@ -6,11 +6,7 @@
  */
 
 import {ProjectConfig} from "@internal/project";
-import {
-	AnyFilePath,
-	UnknownPath,
-	createUnknownPath,
-} from "@internal/path";
+import {AnyFilePath, UnknownPath, createUnknownPath} from "@internal/path";
 import {ExtensionHandler} from "./types";
 import {
 	cjsHandler,

--- a/internal/core/common/file-handlers/json.ts
+++ b/internal/core/common/file-handlers/json.ts
@@ -11,7 +11,7 @@ import {
 	stringifyJSON,
 	stringifyRJSONFromConsumer,
 } from "@internal/codec-json";
-import {createAbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {createAbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {
 	ExtensionHandler,
 	ExtensionHandlerMethodInfo,
@@ -39,7 +39,7 @@ export const jsonHandler: ExtensionHandler = {
 
 		const real = createAbsoluteFilePath(file.real);
 		const sourceText = await worker.readFile(real);
-		const path = createUnknownFilePath(uid);
+		const path = createUnknownPath(uid);
 
 		let formatted: string = sourceText;
 
@@ -84,7 +84,7 @@ export const jsonHandler: ExtensionHandler = {
 
 		// Parse the JSON to make sure it's valid
 		const obj = parseJSON({
-			path: createUnknownFilePath(file.uid),
+			path: createUnknownPath(file.uid),
 			input: src,
 		});
 

--- a/internal/core/common/file-handlers/types.ts
+++ b/internal/core/common/file-handlers/types.ts
@@ -15,7 +15,7 @@ import {
 } from "@internal/diagnostics";
 import * as compiler from "@internal/compiler";
 import {AnyRoot, ConstJSSourceType} from "@internal/ast";
-import {UnknownFilePath} from "@internal/path";
+import {UnknownPath} from "@internal/path";
 
 export type ExtensionLintResult = {
 	mtime: undefined | number;
@@ -36,7 +36,7 @@ export type ExtensionHandlerMethodInfo = {
 export type ExtensionParseInfo = ExtensionHandlerMethodInfo & {
 	sourceTypeJS: ConstJSSourceType;
 	manifestPath: undefined | string;
-	path: UnknownFilePath;
+	path: UnknownPath;
 };
 
 export type PartialExtensionHandler = {

--- a/internal/core/server/Server.ts
+++ b/internal/core/server/Server.ts
@@ -52,7 +52,7 @@ import {
 
 import setupGlobalErrorHandlers from "../common/utils/setupGlobalErrorHandlers";
 
-import {AbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {AbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {Dict, ErrorCallback, mergeObjects} from "@internal/typescript-helpers";
 import LSPServer from "./lsp/LSPServer";
 import ServerReporter from "./ServerReporter";
@@ -208,7 +208,7 @@ export default class Server {
 				markupOptions: {
 					userConfig: this.userConfig,
 					humanizeFilename: (filename) => {
-						const path = createUnknownFilePath(filename);
+						const path = createUnknownPath(filename);
 						if (path.isAbsolute()) {
 							const remote = this.projectManager.getRemoteFromLocalPath(
 								path.assertAbsolute(),
@@ -859,7 +859,7 @@ export default class Server {
 			// A type-safe wrapper for retrieving command flags
 			// TODO perhaps present this as JSON or something if this isn't a request from the CLI?
 			const flagsConsumer = consume({
-				filePath: createUnknownFilePath("argv"),
+				filePath: createUnknownPath("argv"),
 				parent: undefined,
 				value: query.commandFlags,
 				onDefinition(def) {

--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -74,9 +74,9 @@ import {
 	AbsoluteFilePathMap,
 	AbsoluteFilePathSet,
 	AnyFilePath,
-	UnknownFilePath,
+	UnknownPath,
 	createAbsoluteFilePath,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 import {Dict, RequiredProps, mergeObjects} from "@internal/typescript-helpers";
 import {ob1Coerce0, ob1Number0, ob1Number1} from "@internal/ob1";
@@ -117,8 +117,8 @@ type WrapRequestDiagnosticOpts = {
 };
 
 type ServerRequestGlobOptions = Omit<GlobOptions, "args" | "relativeDirectory"> & {
-	args?: Array<UnknownFilePath | string>;
-	tryAlternateArg?: (path: UnknownFilePath) => undefined | UnknownFilePath;
+	args?: Array<UnknownPath | string>;
+	tryAlternateArg?: (path: UnknownPath) => undefined | UnknownPath;
 	ignoreArgumentMisses?: boolean;
 	ignoreProjectIgnore?: boolean;
 	disabledDiagnosticCategory?: DiagnosticCategory;
@@ -491,7 +491,7 @@ export default class ServerRequest {
 		return await this.server.resolver.resolveEntryAssertPath(
 			{
 				...this.getResolverOptionsFromFlags(),
-				source: createUnknownFilePath(arg),
+				source: createUnknownPath(arg),
 			},
 			{location: this.getDiagnosticLocationFromFlags({type: "arg", key: index})},
 		);
@@ -1236,7 +1236,7 @@ export default class ServerRequest {
 		}
 
 		for (let i = 0; i < rawArgs.length; i++) {
-			const path = createUnknownFilePath(rawArgs[i]);
+			const path = createUnknownPath(rawArgs[i]);
 			let abs: AbsoluteFilePath;
 
 			if (path.isAbsolute()) {

--- a/internal/core/server/bundler/Bundler.ts
+++ b/internal/core/server/bundler/Bundler.ts
@@ -16,7 +16,7 @@ import {
 } from "../../common/types/bundler";
 import DependencyGraph from "../dependencies/DependencyGraph";
 import BundleRequest, {BundleOptions} from "./BundleRequest";
-import {AbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {AbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {
 	JSONManifest,
 	ManifestDefinition,
@@ -65,7 +65,7 @@ export default class Bundler {
 		const res = await this.server.resolver.resolveEntryAssert({
 			...this.config.resolver,
 			origin: cwd,
-			source: createUnknownFilePath(unresolvedEntry),
+			source: createUnknownPath(unresolvedEntry),
 		});
 
 		const {server} = this;
@@ -76,7 +76,7 @@ export default class Bundler {
 			...this.config.resolver,
 			origin: cwd,
 			requestedType: "package",
-			source: createUnknownFilePath(unresolvedEntry),
+			source: createUnknownPath(unresolvedEntry),
 		});
 		const manifestRoot: undefined | AbsoluteFilePath =
 			manifestRootResolved.type === "FOUND"
@@ -333,7 +333,7 @@ export default class Bundler {
 					{
 						...this.config.resolver,
 						origin: manifestDef.directory,
-						source: createUnknownFilePath(relative).toExplicitRelative(),
+						source: createUnknownPath(relative).toExplicitRelative(),
 					},
 					{
 						location,

--- a/internal/core/server/commands/check.ts
+++ b/internal/core/server/commands/check.ts
@@ -18,7 +18,7 @@ import {
 } from "@internal/compiler";
 import {Consumer} from "@internal/consume";
 import {commandCategories} from "@internal/core/common/commands";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {LINTABLE_EXTENSIONS} from "@internal/core/common/file-handlers";
 
 type Flags = {
@@ -91,7 +91,7 @@ export default createServerCommand<Flags>({
 
 			// Only include lintable files
 			args = args.filter((arg) => {
-				const path = createUnknownFilePath(arg);
+				const path = createUnknownPath(arg);
 
 				for (const ext of LINTABLE_EXTENSIONS) {
 					if (path.hasEndExtension(ext)) {

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -9,7 +9,7 @@ import {ServerRequest} from "@internal/core";
 import {commandCategories} from "../../common/commands";
 import {createServerCommand} from "../commands";
 import {assertHardMeta, normalizeProjectConfig} from "@internal/project";
-import {AbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {AbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {markup} from "@internal/markup";
 import {interceptDiagnostics} from "@internal/diagnostics";
 import {Consumer} from "@internal/consume";
@@ -219,7 +219,7 @@ export const setDirectory = createServerCommand<Flags>({
 		req.expectArgumentLength(2);
 
 		let value = req.query.args[1];
-		const path = createUnknownFilePath(value);
+		const path = createUnknownPath(value);
 
 		// If the value is an absolute path, then make it relative to the project directory
 		if (path.isAbsolute()) {

--- a/internal/core/server/commands/resolve.ts
+++ b/internal/core/server/commands/resolve.ts
@@ -8,7 +8,7 @@
 import {ServerRequest} from "@internal/core";
 import {commandCategories} from "../../common/commands";
 import {createServerCommand} from "../commands";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {markup} from "@internal/markup";
 
 export default createServerCommand({
@@ -43,7 +43,7 @@ export default createServerCommand({
 		const query = {
 			...req.getResolverOptionsFromFlags(),
 			origin,
-			source: createUnknownFilePath(relative),
+			source: createUnknownPath(relative),
 		};
 
 		const resolved = await server.resolver.resolveEntryAssert(

--- a/internal/core/server/dependencies/DependencyGraph.ts
+++ b/internal/core/server/dependencies/DependencyGraph.ts
@@ -24,7 +24,7 @@ import {WorkerAnalyzeDependencyResult} from "../../common/bridges/WorkerBridge";
 import {
 	AbsoluteFilePath,
 	AbsoluteFilePathMap,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 
 import {markup} from "@internal/markup";
@@ -355,7 +355,7 @@ export default class DependencyGraph {
 							{
 								...this.resolverOpts,
 								origin,
-								source: createUnknownFilePath(source),
+								source: createUnknownPath(source),
 							},
 							dep.loc === undefined
 								? undefined

--- a/internal/core/server/fs/Resolver.test.ts
+++ b/internal/core/server/fs/Resolver.test.ts
@@ -1,6 +1,6 @@
 import {test} from "rome";
 import {createIntegrationTest} from "@internal/test-helpers";
-import {AbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {AbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {ResolverQueryResponseFound} from "./Resolver";
 
 function foundToRelativePath(
@@ -26,7 +26,7 @@ test(
 					cwd,
 					await server.resolver.resolveEntryAssert({
 						origin: cwd,
-						source: createUnknownFilePath("./index"),
+						source: createUnknownPath("./index"),
 					}),
 				),
 				"index.js",
@@ -38,7 +38,7 @@ test(
 					cwd,
 					await server.resolver.resolveEntryAssert({
 						origin: cwd,
-						source: createUnknownFilePath("./index"),
+						source: createUnknownPath("./index"),
 						platform: "ios",
 					}),
 				),

--- a/internal/core/server/fs/Resolver.ts
+++ b/internal/core/server/fs/Resolver.ts
@@ -19,7 +19,7 @@ import {
 	AbsoluteFilePath,
 	AnyFilePath,
 	RelativeFilePath,
-	URLFilePath,
+	URLPath,
 	createFilePathFromSegments,
 	createRelativeFilePath,
 } from "@internal/path";
@@ -102,7 +102,7 @@ function request(
 const NODE_MODULES = "node_modules";
 
 export type ResolverRemoteQuery = Omit<ResolverOptions, "origin"> & {
-	origin: URLFilePath | AbsoluteFilePath;
+	origin: URLPath | AbsoluteFilePath;
 	source: AnyFilePath;
 	// Allows a resolution to stop at a directory or package boundary
 	requestedType?: "package" | "directory";

--- a/internal/core/server/fs/resolverSuggest.ts
+++ b/internal/core/server/fs/resolverSuggest.ts
@@ -328,9 +328,7 @@ function tryPathSuggestions(
 					server,
 					resolver,
 					suggestions,
-					path: createUnknownPath(rating.target).append(
-						...segments.slice(1),
-					).assertAbsolute(),
+					path: createUnknownPath(rating.target).append(...segments.slice(1)).assertAbsolute(),
 				});
 			}
 		}

--- a/internal/core/server/fs/resolverSuggest.ts
+++ b/internal/core/server/fs/resolverSuggest.ts
@@ -19,7 +19,7 @@ import {
 	descriptions,
 } from "@internal/diagnostics";
 import {orderBySimilarity} from "@internal/string-utils";
-import {AbsoluteFilePath, createUnknownFilePath} from "@internal/path";
+import {AbsoluteFilePath, createUnknownPath} from "@internal/path";
 import {PLATFORMS, Server} from "@internal/core";
 import {StaticMarkups, markup} from "@internal/markup";
 
@@ -316,7 +316,7 @@ function tryPathSuggestions(
 			const ratings = orderBySimilarity(
 				path.getExtensionlessBasename(),
 				entries.map((target) => {
-					return createUnknownFilePath(target).getExtensionlessBasename();
+					return createUnknownPath(target).getExtensionlessBasename();
 				}),
 				{
 					minRating: MIN_SIMILARITY,
@@ -328,7 +328,7 @@ function tryPathSuggestions(
 					server,
 					resolver,
 					suggestions,
-					path: createUnknownFilePath(rating.target).append(
+					path: createUnknownPath(rating.target).append(
 						...segments.slice(1),
 					).assertAbsolute(),
 				});

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -40,8 +40,8 @@ import {
 	AbsoluteFilePathMap,
 	AbsoluteFilePathSet,
 	AnyFilePath,
-	URLFilePath,
-	UnknownFilePathMap,
+	URLPath,
+	UnknownPathMap,
 	createAbsoluteFilePath,
 } from "@internal/path";
 import {FileReference} from "../../common/types/files";
@@ -138,7 +138,7 @@ export default class ProjectManager {
 		// We maintain these maps so we can reverse any uids, and protect against collisions
 		this.uidToFilename = new Map();
 		this.filenameToUid = new AbsoluteFilePathMap();
-		this.remoteToLocalPath = new UnknownFilePathMap();
+		this.remoteToLocalPath = new UnknownPathMap();
 		this.localPathToRemote = new AbsoluteFilePathMap();
 
 		this.evictingProjectLock = new SingleLocker();
@@ -152,8 +152,8 @@ export default class ProjectManager {
 	private uidToFilename: Map<string, AbsoluteFilePath>;
 	private filenameToUid: AbsoluteFilePathMap<string>;
 
-	private remoteToLocalPath: UnknownFilePathMap<AbsoluteFilePath>;
-	private localPathToRemote: AbsoluteFilePathMap<URLFilePath>;
+	private remoteToLocalPath: UnknownPathMap<AbsoluteFilePath>;
+	private localPathToRemote: AbsoluteFilePathMap<URLPath>;
 
 	// Lock to prevent race conditions that result in the same project being loaded multiple times at once
 	private projectLoadingLocks: FilePathLocker;
@@ -217,7 +217,7 @@ export default class ProjectManager {
 		}
 	}
 
-	public getRemoteFromLocalPath(path: AbsoluteFilePath): undefined | URLFilePath {
+	public getRemoteFromLocalPath(path: AbsoluteFilePath): undefined | URLPath {
 		return this.localPathToRemote.get(path);
 	}
 
@@ -363,7 +363,7 @@ export default class ProjectManager {
 
 	public getURLFileReference(
 		local: AbsoluteFilePath,
-		url: URLFilePath,
+		url: URLPath,
 	): FileReference {
 		if (!this.remoteToLocalPath.has(url)) {
 			this.remoteToLocalPath.set(url, local);

--- a/internal/core/server/web/WebRequest.ts
+++ b/internal/core/server/web/WebRequest.ts
@@ -15,7 +15,7 @@ import Bundler from "../bundler/Bundler";
 import {WebSocketInterface, createKey} from "@internal/codec-websocket";
 import {Reporter, ReporterCaptureStream} from "@internal/cli-reporter";
 import {createBridgeFromWebSocketInterface} from "@internal/events";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {WebServer} from "./index";
 import {ProjectDefinition} from "@internal/project";
 import {ConsumableUrl, consumeUrl} from "@internal/codec-url";
@@ -265,7 +265,7 @@ export default class WebRequest {
 		);
 		const resolved = await this.server.resolver.resolveEntryAssertPath({
 			origin: this.serverRequest.client.flags.cwd,
-			source: createUnknownFilePath("@internal/web-ui"),
+			source: createUnknownPath("@internal/web-ui"),
 		});
 		const bundle = await bundler.bundle(resolved);
 		res.end(bundle.entry.js.content);

--- a/internal/core/test-worker/TestAPI.ts
+++ b/internal/core/test-worker/TestAPI.ts
@@ -513,7 +513,7 @@ export default class TestAPI implements TestHelper {
 					getErrorStackAdvice(
 						getErrorStructure(err),
 						{
-							title: markup`Incorrect error stack trace`
+							title: markup`Incorrect error stack trace`,
 						},
 					),
 					1,
@@ -542,7 +542,7 @@ export default class TestAPI implements TestHelper {
 					getErrorStackAdvice(
 						getErrorStructure(err),
 						{
-							title: markup`Incorrect error stack trace`
+							title: markup`Incorrect error stack trace`,
 						},
 					),
 					1,
@@ -564,7 +564,7 @@ export default class TestAPI implements TestHelper {
 				{
 					title: markup`t.notThrows() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
 						err.message,
-					)}`
+					)}`,
 				},
 			);
 			this.fail(message, advice, 1);
@@ -583,7 +583,7 @@ export default class TestAPI implements TestHelper {
 				{
 					title: markup`t.notThrowsAsync() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
 						err.message,
-					)}`
+					)}`,
 				},
 			);
 			this.fail(message, advice, 1);

--- a/internal/core/test-worker/TestAPI.ts
+++ b/internal/core/test-worker/TestAPI.ts
@@ -512,7 +512,9 @@ export default class TestAPI implements TestHelper {
 					)} but got ${err.name}: ${JSON.stringify(err.message)}`,
 					getErrorStackAdvice(
 						getErrorStructure(err),
-						markup`Incorrect error stack trace`,
+						{
+							title: markup`Incorrect error stack trace`
+						},
 					),
 					1,
 				);
@@ -539,7 +541,9 @@ export default class TestAPI implements TestHelper {
 					)} but got ${err.name}: ${JSON.stringify(err.message)}`,
 					getErrorStackAdvice(
 						getErrorStructure(err),
-						markup`Incorrect error stack trace`,
+						{
+							title: markup`Incorrect error stack trace`
+						},
 					),
 					1,
 				);
@@ -557,9 +561,11 @@ export default class TestAPI implements TestHelper {
 		} catch (err) {
 			const advice = getErrorStackAdvice(
 				getErrorStructure(err),
-				markup`t.notThrows() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
-					err.message,
-				)}`,
+				{
+					title: markup`t.notThrows() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
+						err.message,
+					)}`
+				},
 			);
 			this.fail(message, advice, 1);
 		}
@@ -574,9 +580,11 @@ export default class TestAPI implements TestHelper {
 		} catch (err) {
 			const advice = getErrorStackAdvice(
 				getErrorStructure(err),
-				markup`t.notThrowsAsync() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
-					err.message,
-				)}`,
+				{
+					title: markup`t.notThrowsAsync() did not expect an error to be thrown but got ${err.name}: ${JSON.stringify(
+						err.message,
+					)}`
+				},
 			);
 			this.fail(message, advice, 1);
 		}

--- a/internal/core/test-worker/TestWorkerRunner.ts
+++ b/internal/core/test-worker/TestWorkerRunner.ts
@@ -403,6 +403,9 @@ export default class TestWorkerRunner {
 				},
 				filename: this.file.real.join(),
 				cleanFrames,
+				stackAdviceOptions: {
+					importantFilenames: [this.file.uid],
+				},
 			},
 		);
 	}

--- a/internal/core/worker/Worker.ts
+++ b/internal/core/worker/Worker.ts
@@ -23,9 +23,9 @@ import {DiagnosticsError} from "@internal/diagnostics";
 import {
 	AbsoluteFilePath,
 	AbsoluteFilePathMap,
-	UnknownFilePathMap,
+	UnknownPathMap,
 	createAbsoluteFilePath,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 import {lstat, readFileText} from "@internal/fs";
 import {FileReference} from "../common/types/files";
@@ -61,7 +61,7 @@ export default class Worker {
 		this.partialManifests = new Map();
 		this.projects = new Map();
 		this.astCache = new AbsoluteFilePathMap();
-		this.moduleSignatureCache = new UnknownFilePathMap();
+		this.moduleSignatureCache = new UnknownPathMap();
 		this.buffers = new AbsoluteFilePathMap();
 		this.virtualModules = new VirtualModules();
 
@@ -119,7 +119,7 @@ export default class Worker {
 	private partialManifests: Map<number, WorkerPartialManifest>;
 	private projects: Map<number, TransformProjectDefinition>;
 	private astCache: AbsoluteFilePathMap<ParseResult>;
-	private moduleSignatureCache: UnknownFilePathMap<ModuleSignature>;
+	private moduleSignatureCache: UnknownPathMap<ModuleSignature>;
 	private buffers: AbsoluteFilePathMap<string>;
 
 	private getPartialManifest(id: number): WorkerPartialManifest {
@@ -321,7 +321,7 @@ export default class Worker {
 			switch (value.type) {
 				case "RESOLVED": {
 					this.moduleSignatureCache.set(
-						createUnknownFilePath(value.graph.filename),
+						createUnknownPath(value.graph.filename),
 						value.graph,
 					);
 					return value.graph;
@@ -335,7 +335,7 @@ export default class Worker {
 
 				case "USE_CACHED": {
 					const cached = this.moduleSignatureCache.get(
-						createUnknownFilePath(value.filename),
+						createUnknownPath(value.filename),
 					);
 					if (cached === undefined) {
 						throw new Error(
@@ -448,7 +448,7 @@ export default class Worker {
 
 		const {sourceText, astModifiedFromSource, ast} = await handler.parse({
 			sourceTypeJS,
-			path: createUnknownFilePath(uid),
+			path: createUnknownPath(uid),
 			manifestPath,
 			mtime,
 			file: ref,

--- a/internal/diagnostics/DiagnosticsNormalizer.ts
+++ b/internal/diagnostics/DiagnosticsNormalizer.ts
@@ -105,6 +105,8 @@ export default class DiagnosticsNormalizer {
 		this.inlineSourceText.set(filename, sourceText);
 	}
 
+	private normalizeFilename(filename: string): string;
+	private normalizeFilename(filename: undefined | string): undefined | string;
 	private normalizeFilename(filename: undefined | string): undefined | string {
 		const {markupOptions} = this;
 		if (markupOptions === undefined || filename === undefined) {
@@ -257,6 +259,7 @@ export default class DiagnosticsNormalizer {
 			case "stacktrace":
 				return {
 					...item,
+					importantFilenames: (item.importantFilenames ?? []).map(filename => this.normalizeFilename(filename)),
 					frames: item.frames.map((frame) => {
 						const {filename, line, column} = frame;
 

--- a/internal/diagnostics/DiagnosticsNormalizer.ts
+++ b/internal/diagnostics/DiagnosticsNormalizer.ts
@@ -105,8 +105,8 @@ export default class DiagnosticsNormalizer {
 		this.inlineSourceText.set(filename, sourceText);
 	}
 
-	private normalizeFilename(filename: string): string;
-	private normalizeFilename(filename: undefined | string): undefined | string;
+	private normalizeFilename(filename: string): string
+	private normalizeFilename(filename: undefined | string): undefined | string
 	private normalizeFilename(filename: undefined | string): undefined | string {
 		const {markupOptions} = this;
 		if (markupOptions === undefined || filename === undefined) {
@@ -259,7 +259,9 @@ export default class DiagnosticsNormalizer {
 			case "stacktrace":
 				return {
 					...item,
-					importantFilenames: (item.importantFilenames ?? []).map(filename => this.normalizeFilename(filename)),
+					importantFilenames: (item.importantFilenames ?? []).map((filename) =>
+						this.normalizeFilename(filename)
+					),
 					frames: item.frames.map((frame) => {
 						const {filename, line, column} = frame;
 

--- a/internal/diagnostics/derive.ts
+++ b/internal/diagnostics/derive.ts
@@ -216,10 +216,13 @@ export function deriveDiagnosticFromErrorStructure(
 		break;
 	}
 
-	const advice = getErrorStackAdvice({
-		...struct,
-		frames,
-	}, opts.stackAdviceOptions);
+	const advice = getErrorStackAdvice(
+		{
+			...struct,
+			frames,
+		},
+		opts.stackAdviceOptions,
+	);
 
 	return {
 		description: {
@@ -246,7 +249,7 @@ export function deriveDiagnosticFromError(
 }
 
 export type DeriveErrorStackAdviceOptions = {
-	title?: StaticMarkup,
+	title?: StaticMarkup;
 	importantFilenames?: Array<string>;
 };
 
@@ -275,9 +278,9 @@ export function getErrorStackAdvice(
 		}
 		cleanStack = cleanStack.trim();
 
-		const cleanStackList = cleanStack.replace(/\n+/g, "\n").split("\n").map((line) =>
-			markup`${line.trim()}`
-		);
+		const cleanStackList = cleanStack.replace(/\n+/g, "\n").split("\n").map((
+			line,
+		) => markup`${line.trim()}`);
 
 		if (cleanStackList.length === 1 && isEmptyMarkup(cleanStackList[0])) {
 			advice.push({

--- a/internal/diagnostics/derive.ts
+++ b/internal/diagnostics/derive.ts
@@ -185,6 +185,7 @@ export type DeriveErrorDiagnosticOptions = {
 	tags?: DiagnosticTags;
 	filename?: string;
 	cleanFrames?: (frames: ErrorFrames) => ErrorFrames;
+	stackAdviceOptions?: DeriveErrorStackAdviceOptions;
 };
 
 export function deriveDiagnosticFromErrorStructure(
@@ -218,7 +219,7 @@ export function deriveDiagnosticFromErrorStructure(
 	const advice = getErrorStackAdvice({
 		...struct,
 		frames,
-	});
+	}, opts.stackAdviceOptions);
 
 	return {
 		description: {
@@ -244,9 +245,14 @@ export function deriveDiagnosticFromError(
 	return deriveDiagnosticFromErrorStructure(getErrorStructure(error), opts);
 }
 
+export type DeriveErrorStackAdviceOptions = {
+	title?: StaticMarkup,
+	importantFilenames?: Array<string>;
+};
+
 export function getErrorStackAdvice(
 	error: Partial<StructuredError>,
-	title?: StaticMarkup,
+	{title, importantFilenames}: DeriveErrorStackAdviceOptions = {},
 ): DiagnosticAdvice {
 	const advice: DiagnosticAdvice = [];
 	const {frames = [], stack} = error;
@@ -269,7 +275,7 @@ export function getErrorStackAdvice(
 		}
 		cleanStack = cleanStack.trim();
 
-		const cleanStackList = cleanStack.split("\n").map((line) =>
+		const cleanStackList = cleanStack.replace(/\n+/g, "\n").split("\n").map((line) =>
 			markup`${line.trim()}`
 		);
 
@@ -350,6 +356,7 @@ export function getErrorStackAdvice(
 			type: "stacktrace",
 			title,
 			frames: adviceFrames,
+			importantFilenames,
 		});
 	}
 

--- a/internal/diagnostics/types.ts
+++ b/internal/diagnostics/types.ts
@@ -186,6 +186,7 @@ export type DiagnosticAdviceStacktrace = {
 	type: "stacktrace";
 	title?: StaticMarkup;
 	truncate?: boolean;
+	importantFilenames?: Array<string>;
 	frames: Array<DiagnosticAdviceStackFrame>;
 };
 

--- a/internal/js-analysis/tests/basic.test.ts
+++ b/internal/js-analysis/tests/basic.test.ts
@@ -10,13 +10,13 @@ import {createDefaultProjectConfig} from "@internal/project";
 import {test} from "rome";
 import {check} from "@internal/js-analysis";
 import {parseJS} from "@internal/js-parser";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 
 async function testCheck(code: string): Promise<Diagnostics> {
 	const ast = parseJS({
 		input: code,
 		sourceType: "module",
-		path: createUnknownFilePath("unknown"),
+		path: createUnknownPath("unknown"),
 	});
 
 	return check({

--- a/internal/js-ast-utils/template.ts
+++ b/internal/js-ast-utils/template.ts
@@ -15,7 +15,7 @@ import {
 import {CompilerContext, Path, signals} from "@internal/compiler";
 import {removeLoc} from "@internal/ast-utils";
 import {parseJS} from "@internal/js-parser";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {isIdentifierish} from "./isIdentifierish";
 import {Dict} from "@internal/typescript-helpers";
 
@@ -68,7 +68,7 @@ function getTemplate(strs: TemplateStringsArray): BuiltTemplate {
 	let ast = parseJS({
 		input: code,
 		sourceType: "template",
-		path: createUnknownFilePath("template"),
+		path: createUnknownPath("template"),
 	});
 
 	// remove `loc` properties

--- a/internal/markup-syntax-highlight/highlightShell.ts
+++ b/internal/markup-syntax-highlight/highlightShell.ts
@@ -1,7 +1,7 @@
 import {HighlightCodeResult} from "./types";
 import {concatMarkup, filePathToMarkup, markup} from "@internal/markup";
 import {concatSplitLinesMarkup, markupToken} from "./utils";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {markupTag} from "@internal/markup/escape";
 
 // Very crude. Should be updated to support hash bangs and other fancy syntax
@@ -28,7 +28,7 @@ export default function highlightShell(
 					return punc;
 				} else {
 					return concatMarkup([
-						filePathToMarkup(createUnknownFilePath(segment.slice(0, -1)), true),
+						filePathToMarkup(createUnknownPath(segment.slice(0, -1)), true),
 						punc,
 					]);
 				}

--- a/internal/markup-syntax-highlight/types.ts
+++ b/internal/markup-syntax-highlight/types.ts
@@ -1,11 +1,11 @@
 import {Number0} from "@internal/ob1";
 import {DiagnosticLanguage, DiagnosticSourceType} from "@internal/diagnostics";
-import {UnknownFilePath} from "@internal/path";
+import {UnknownPath} from "@internal/path";
 import {MarkupTokenType, StaticMarkup} from "@internal/markup";
 import {AnyMarkups} from "@internal/markup/escape";
 
 export type AnsiHighlightOptions = {
-	path: UnknownFilePath;
+	path: UnknownPath;
 	input: string;
 	sourceTypeJS: undefined | DiagnosticSourceType;
 	language: DiagnosticLanguage;

--- a/internal/markup/escape.ts
+++ b/internal/markup/escape.ts
@@ -11,8 +11,8 @@ import {
 	AbsoluteFilePath,
 	AnyFilePath,
 	RelativeFilePath,
-	URLFilePath,
-	UnknownFilePath,
+	URLPath,
+	UnknownPath,
 } from "@internal/path";
 
 type MarkupPart = StaticMarkup | RawMarkup | string;
@@ -66,7 +66,7 @@ export function filePathToMarkup(
 	explicit: boolean = false,
 ): StaticMarkup {
 	let tagName: MarkupTagName = "filelink";
-	if (path instanceof URLFilePath) {
+	if (path instanceof URLPath) {
 		tagName = "hyperlink";
 	}
 
@@ -131,8 +131,8 @@ export function markup(
 		} else if (
 			value instanceof RelativeFilePath ||
 			value instanceof AbsoluteFilePath ||
-			value instanceof URLFilePath ||
-			value instanceof UnknownFilePath
+			value instanceof URLPath ||
+			value instanceof UnknownPath
 		) {
 			parts.push(filePathToMarkup(value));
 		} else {

--- a/internal/markup/types.ts
+++ b/internal/markup/types.ts
@@ -97,6 +97,7 @@ export type MarkupFormatOptions = {
 	humanizeFilename?: MarkupFormatFilenameHumanizer;
 	cwd?: AbsoluteFilePath;
 };
+
 export type MarkupFormatNormalizeOptions = MarkupFormatOptions & {
 	stripPositions?: boolean;
 	stripFilelinkText?: boolean;

--- a/internal/markup/util.ts
+++ b/internal/markup/util.ts
@@ -1,7 +1,7 @@
 import {Consumer, consumeUnknown} from "@internal/consume";
 import {MarkupFormatOptions, MarkupParsedAttributes} from "./types";
 import {humanizeNumber} from "@internal/string-utils";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {ob1Coerce0, ob1Coerce1, ob1Get0, ob1Get1} from "@internal/ob1";
 import {StaticMarkup} from "./escape";
 
@@ -33,7 +33,7 @@ export function humanizeMarkupFilename(
 		}
 	}
 
-	return createUnknownFilePath(filename).format(opts.cwd);
+	return createUnknownPath(filename).format(opts.cwd);
 }
 
 export function buildFileLink(

--- a/internal/parser-core/ParserCore.ts
+++ b/internal/parser-core/ParserCore.ts
@@ -28,7 +28,7 @@ import {
 	descriptions,
 } from "@internal/diagnostics";
 import {AnyComment, AnyNode, RootBase} from "@internal/ast";
-import {UnknownFilePath, createUnknownFilePath} from "@internal/path";
+import {UnknownPath, createUnknownPath} from "@internal/path";
 import {
 	Number0,
 	Number1,
@@ -74,7 +74,7 @@ export default class ParserCore<
 		} = opts;
 
 		// Input information
-		this.path = path === undefined ? undefined : createUnknownFilePath(path);
+		this.path = path === undefined ? undefined : createUnknownPath(path);
 		this.filename = this.path === undefined ? undefined : this.path.join();
 		this.mtime = mtime;
 		this.input = normalizeInput(opts);
@@ -125,7 +125,7 @@ export default class ParserCore<
 	private eofToken: EOFToken;
 	protected ignoreWhitespaceTokens: boolean;
 
-	public path: undefined | UnknownFilePath;
+	public path: undefined | UnknownPath;
 	public filename: undefined | string;
 	public input: string;
 	protected mtime: undefined | number;
@@ -147,7 +147,7 @@ export default class ParserCore<
 		};
 	}
 
-	protected getPathAssert(): UnknownFilePath {
+	protected getPathAssert(): UnknownPath {
 		const {path} = this;
 		if (path === undefined) {
 			throw new Error("Path expected but none was passed to this Parser");
@@ -792,7 +792,7 @@ export class ParserWithRequiredPath<
 		this.path = this.getPathAssert();
 	}
 
-	public path: UnknownFilePath;
+	public path: UnknownPath;
 	public filename: string;
 }
 

--- a/internal/path/collections.ts
+++ b/internal/path/collections.ts
@@ -9,10 +9,10 @@ import {
 	AbsoluteFilePath,
 	AnyFilePath,
 	RelativeFilePath,
-	UnknownFilePath,
+	UnknownPath,
 	createAbsoluteFilePath,
 	createRelativeFilePath,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "./index";
 
 // Sometimes we don't want to have to deal with what a FilePath serializes into
@@ -180,16 +180,16 @@ export class RelativeFilePathMap<Value>
 	}
 }
 
-export class UnknownFilePathMap<Value>
+export class UnknownPathMap<Value>
 	extends BaseFilePathMap<AnyFilePath, Value> {
 	public type: "unknown" = "unknown";
 
-	public createKey(str: string): UnknownFilePath {
-		return createUnknownFilePath(str);
+	public createKey(str: string): UnknownPath {
+		return createUnknownPath(str);
 	}
 
-	public keysToSet(): UnknownFilePathSet {
-		return new UnknownFilePathSet(this.keys());
+	public keysToSet(): UnknownPathSet {
+		return new UnknownPathSet(this.keys());
 	}
 }
 
@@ -211,16 +211,16 @@ export class RelativeFilePathSet
 	}
 }
 
-export class UnknownFilePathSet
-	extends BaseFilePathSet<AnyFilePath, UnknownFilePathMap<void>> {
+export class UnknownPathSet
+	extends BaseFilePathSet<AnyFilePath, UnknownPathMap<void>> {
 	public type: "unknown" = "unknown";
 
-	createMap(): UnknownFilePathMap<void> {
-		return new UnknownFilePathMap();
+	createMap(): UnknownPathMap<void> {
+		return new UnknownPathMap();
 	}
 }
 
 export type AnyFilePathSet =
 	| AbsoluteFilePathSet
 	| RelativeFilePathSet
-	| UnknownFilePathSet;
+	| UnknownPathSet;

--- a/internal/path/collections.ts
+++ b/internal/path/collections.ts
@@ -20,7 +20,7 @@ import {
 // to speed up the usage of FilePaths in these scenarios.
 // The API here attempts to match what is expected from the native classes, however we may deviate from it
 // to avoid the usage of getters and generator/symbol indirection for iteration.
-abstract class BaseFilePathMap<FilePath extends AnyFilePath, Value> {
+abstract class BasePathMap<FilePath extends AnyFilePath, Value> {
 	constructor(entries?: Array<[FilePath, Value]>) {
 		this.joinedToValue = new Map();
 		this.joinedToPath = new Map();
@@ -92,9 +92,9 @@ abstract class BaseFilePathMap<FilePath extends AnyFilePath, Value> {
 	}
 }
 
-abstract class BaseFilePathSet<
+abstract class BasePathSet<
 	FilePath extends AnyFilePath,
-	FilePathMap extends BaseFilePathMap<FilePath, void>
+	FilePathMap extends BasePathMap<FilePath, void>
 > {
 	constructor(entries?: Iterable<FilePath>) {
 		this.map = this.createMap();
@@ -155,7 +155,7 @@ abstract class BaseFilePathSet<
 }
 
 export class AbsoluteFilePathMap<Value>
-	extends BaseFilePathMap<AbsoluteFilePath, Value> {
+	extends BasePathMap<AbsoluteFilePath, Value> {
 	public type: "absolute" = "absolute";
 
 	public createKey(str: string): AbsoluteFilePath {
@@ -168,7 +168,7 @@ export class AbsoluteFilePathMap<Value>
 }
 
 export class RelativeFilePathMap<Value>
-	extends BaseFilePathMap<RelativeFilePath, Value> {
+	extends BasePathMap<RelativeFilePath, Value> {
 	public type: "relative" = "relative";
 
 	public createKey(str: string): RelativeFilePath {
@@ -180,7 +180,7 @@ export class RelativeFilePathMap<Value>
 	}
 }
 
-export class UnknownPathMap<Value> extends BaseFilePathMap<AnyFilePath, Value> {
+export class UnknownPathMap<Value> extends BasePathMap<AnyFilePath, Value> {
 	public type: "unknown" = "unknown";
 
 	public createKey(str: string): UnknownPath {
@@ -193,7 +193,7 @@ export class UnknownPathMap<Value> extends BaseFilePathMap<AnyFilePath, Value> {
 }
 
 export class AbsoluteFilePathSet
-	extends BaseFilePathSet<AbsoluteFilePath, AbsoluteFilePathMap<void>> {
+	extends BasePathSet<AbsoluteFilePath, AbsoluteFilePathMap<void>> {
 	public type: "absolute" = "absolute";
 
 	createMap(): AbsoluteFilePathMap<void> {
@@ -202,7 +202,7 @@ export class AbsoluteFilePathSet
 }
 
 export class RelativeFilePathSet
-	extends BaseFilePathSet<RelativeFilePath, RelativeFilePathMap<void>> {
+	extends BasePathSet<RelativeFilePath, RelativeFilePathMap<void>> {
 	public type: "relative" = "relative";
 
 	createMap(): RelativeFilePathMap<void> {
@@ -211,7 +211,7 @@ export class RelativeFilePathSet
 }
 
 export class UnknownPathSet
-	extends BaseFilePathSet<AnyFilePath, UnknownPathMap<void>> {
+	extends BasePathSet<AnyFilePath, UnknownPathMap<void>> {
 	public type: "unknown" = "unknown";
 
 	createMap(): UnknownPathMap<void> {

--- a/internal/path/collections.ts
+++ b/internal/path/collections.ts
@@ -180,8 +180,7 @@ export class RelativeFilePathMap<Value>
 	}
 }
 
-export class UnknownPathMap<Value>
-	extends BaseFilePathMap<AnyFilePath, Value> {
+export class UnknownPathMap<Value> extends BaseFilePathMap<AnyFilePath, Value> {
 	public type: "unknown" = "unknown";
 
 	public createKey(str: string): UnknownPath {

--- a/internal/path/index.test.ts
+++ b/internal/path/index.test.ts
@@ -8,7 +8,7 @@
 import {
 	createAbsoluteFilePath,
 	createRelativeFilePath,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 import {test} from "rome";
 
@@ -98,7 +98,7 @@ for (let i = 0; i < segmentTests.length; i++) {
 	test(
 		`segments: ${i}: ${loc}`,
 		(t) => {
-			t.looksLike(createUnknownFilePath(loc).parsed.segments, expectedSegments);
+			t.looksLike(createUnknownPath(loc).parsed.segments, expectedSegments);
 		},
 	);
 }
@@ -114,6 +114,19 @@ test(
 		t.inlineSnapshot(
 			createAbsoluteFilePath("/bar").append("~/foo").parsed.segments,
 			'Array [\n\t""\n\t"bar"\n\t"~"\n\t"foo"\n]',
+		);
+	},
+);
+
+test(
+	"getUnique",
+	(t) => {
+		t.inlineSnapshot(createRelativeFilePath(".").getUnique().join(), ".");
+		t.inlineSnapshot(createRelativeFilePath("./foo").getUnique().join(), "foo");
+		t.inlineSnapshot(createRelativeFilePath("foo/").getUnique().join(), "foo");
+		t.inlineSnapshot(
+			createRelativeFilePath("foo/bar").getUnique().join(),
+			"foo/bar",
 		);
 	},
 );

--- a/internal/path/index.ts
+++ b/internal/path/index.ts
@@ -583,9 +583,7 @@ export class AbsoluteFilePath extends BaseFilePath<AbsoluteFilePath> {
 		return paths;
 	}
 
-	public resolveMaybeUrl(
-		otherRaw: FilePathOrString,
-	): URLPath | AbsoluteFilePath {
+	public resolveMaybeUrl(otherRaw: FilePathOrString): URLPath | AbsoluteFilePath {
 		const other = toFilePath(otherRaw, "url");
 		if (other.isURL()) {
 			return other.assertURL();
@@ -653,10 +651,7 @@ export class URLPath extends BaseFilePath<URLPath> {
 		return this;
 	}
 
-	protected _fork(
-		parsed: ParsedPath,
-		opts: FilePathMemo<URLPath>,
-	): URLPath {
+	protected _fork(parsed: ParsedPath, opts: FilePathMemo<URLPath>): URLPath {
 		return new URLPath(parsed, opts);
 	}
 
@@ -730,11 +725,13 @@ type PathTypeHint = "absolute" | "relative" | "url" | "auto";
 function parsePathSegments(
 	segments: PathSegments,
 	hint: PathTypeHint,
-	overrides: Pick<Partial<ParsedPath>, "explicitRelative" | "explicitDirectory"> = {},
+	overrides: Pick<Partial<ParsedPath>, "explicitRelative" | "explicitDirectory"> = {
+
+	},
 ): ParsedPath {
 	let absoluteType: ParsedPathAbsoluteType = "posix";
 	let absoluteTarget: undefined | string;
-	let firstSeg = segments[0] as undefined | string;
+	let firstSeg = (segments[0] as undefined | string);
 
 	// Detect URL
 	if (

--- a/internal/path/index.ts
+++ b/internal/path/index.ts
@@ -33,7 +33,7 @@ function toFilePath(
 	hint: PathTypeHint,
 ): AnyFilePath {
 	if (typeof pathOrString === "string") {
-		return createUnknownFilePath(pathOrString, hint);
+		return createUnknownPath(pathOrString, hint);
 	} else {
 		return pathOrString;
 	}
@@ -42,10 +42,10 @@ function toFilePath(
 export * from "./collections";
 
 export type AnyFilePath =
-	| UnknownFilePath
+	| UnknownPath
 	| AbsoluteFilePath
 	| RelativeFilePath
-	| URLFilePath;
+	| URLPath;
 
 export type PathSegments = Array<string>;
 
@@ -84,8 +84,8 @@ export abstract class BaseFilePath<Super extends AnyFilePath = AnyFilePath> {
 		};
 	}
 
-	public toUnknown(): UnknownFilePath {
-		return new UnknownFilePath(this.parsed, this.getPortableMemo());
+	public toUnknown(): UnknownPath {
+		return new UnknownPath(this.parsed, this.getPortableMemo());
 	}
 
 	public addExtension(ext: string, clearExt: boolean = false): Super {
@@ -210,9 +210,9 @@ export abstract class BaseFilePath<Super extends AnyFilePath = AnyFilePath> {
 		}
 	}
 
-	public assertURL(): URLFilePath {
+	public assertURL(): URLPath {
 		if (this.isURL()) {
-			return new URLFilePath(this.parsed, this.getPortableMemo());
+			return new URLPath(this.parsed, this.getPortableMemo());
 		} else {
 			throw new Error(
 				`Expected URL file path but got: ${JSON.stringify(this.join())}`,
@@ -507,15 +507,15 @@ export abstract class BaseFilePath<Super extends AnyFilePath = AnyFilePath> {
 	}
 }
 
-export class UnknownFilePath extends BaseFilePath<UnknownFilePath> {
+export class UnknownPath extends BaseFilePath<UnknownPath> {
 	protected _fork(
 		parsed: ParsedPath,
-		opts: FilePathMemo<UnknownFilePath>,
-	): UnknownFilePath {
-		return new UnknownFilePath(parsed, opts);
+		opts: FilePathMemo<UnknownPath>,
+	): UnknownPath {
+		return new UnknownPath(parsed, opts);
 	}
 
-	protected _assert(): UnknownFilePath {
+	protected _assert(): UnknownPath {
 		return this;
 	}
 }
@@ -585,7 +585,7 @@ export class AbsoluteFilePath extends BaseFilePath<AbsoluteFilePath> {
 
 	public resolveMaybeUrl(
 		otherRaw: FilePathOrString,
-	): URLFilePath | AbsoluteFilePath {
+	): URLPath | AbsoluteFilePath {
 		const other = toFilePath(otherRaw, "url");
 		if (other.isURL()) {
 			return other.assertURL();
@@ -639,28 +639,28 @@ export class AbsoluteFilePath extends BaseFilePath<AbsoluteFilePath> {
 		}
 		finalSegments = finalSegments.concat(relative);
 
-		return new UnknownFilePath(
+		return new UnknownPath(
 			parsePathSegments(finalSegments, "relative"),
 			createEmptyMemo(),
 		);
 	}
 }
 
-export class URLFilePath extends BaseFilePath<URLFilePath> {
+export class URLPath extends BaseFilePath<URLPath> {
 	protected type: "url" = "url";
 
-	protected _assert(): URLFilePath {
+	protected _assert(): URLPath {
 		return this;
 	}
 
 	protected _fork(
 		parsed: ParsedPath,
-		opts: FilePathMemo<URLFilePath>,
-	): URLFilePath {
-		return new URLFilePath(parsed, opts);
+		opts: FilePathMemo<URLPath>,
+	): URLPath {
+		return new URLPath(parsed, opts);
 	}
 
-	public assertURL(): URLFilePath {
+	public assertURL(): URLPath {
 		return this;
 	}
 
@@ -675,19 +675,19 @@ export class URLFilePath extends BaseFilePath<URLFilePath> {
 	public getProtocol(): string {
 		const {absoluteTarget} = this.parsed;
 		if (absoluteTarget === undefined) {
-			throw new Error("Expected a URLFilePath to always have an absoluteTarget");
+			throw new Error("Expected a URLPath to always have an absoluteTarget");
 		}
 		return absoluteTarget;
 	}
 
-	public resolve(path: AnyFilePath): URLFilePath {
+	public resolve(path: AnyFilePath): URLPath {
 		if (path.isURL()) {
 			return path.assertURL();
 		} else if (path.isAbsolute()) {
 			// Get the segments that include the protocol and domain
 			const domainSegments = this.getSegments().slice(0, 3);
 			const finalSegments = [...domainSegments, ...path.getSegments()];
-			return new URLFilePath(
+			return new URLPath(
 				parsePathSegments(finalSegments, "auto"),
 				createEmptyMemo(),
 			);
@@ -730,16 +730,15 @@ type PathTypeHint = "absolute" | "relative" | "url" | "auto";
 function parsePathSegments(
 	segments: PathSegments,
 	hint: PathTypeHint,
-	overrides: Pick<Partial<ParsedPath>, "explicitRelative" | "explicitDirectory"> = {
-
-	},
+	overrides: Pick<Partial<ParsedPath>, "explicitRelative" | "explicitDirectory"> = {},
 ): ParsedPath {
 	let absoluteType: ParsedPathAbsoluteType = "posix";
 	let absoluteTarget: undefined | string;
-	let firstSeg = segments[0];
+	let firstSeg = segments[0] as undefined | string;
 
 	// Detect URL
 	if (
+		firstSeg !== undefined &&
 		!isWindowsDrive(firstSeg) &&
 		firstSeg[firstSeg.length - 1] === ":" &&
 		segments[1] === ""
@@ -795,7 +794,7 @@ function parsePathSegments(
 			absoluteType = "windows-unc";
 			absoluteTarget = `unc:${name}`;
 		}
-	} else if (isWindowsDrive(firstSeg)) {
+	} else if (firstSeg !== undefined && isWindowsDrive(firstSeg)) {
 		const drive = firstSeg.toUpperCase();
 		absoluteSegments.push(drive);
 		absoluteType = "windows-drive";
@@ -809,7 +808,7 @@ function parsePathSegments(
 		segments: pathSegments,
 	} = normalizeSegments(segments, segmentOffset, absoluteSegments);
 
-	const parsed: ParsedPath = {
+	return {
 		explicitDirectory: overrides.explicitDirectory || explicitDirectory,
 		explicitRelative: overrides.explicitRelative || explicitRelative,
 		segments: pathSegments,
@@ -817,20 +816,6 @@ function parsePathSegments(
 		absoluteTarget,
 		hint,
 	};
-
-	if (
-		parsed.segments.length === 0 &&
-		!parsed.explicitDirectory &&
-		!parsed.explicitRelative
-	) {
-		throw new Error(
-			`Segments were normalized to an empty array. Original: ${JSON.stringify(
-				segments,
-			)}`,
-		);
-	}
-
-	return parsed;
 }
 
 function normalizeSegments(
@@ -899,27 +884,27 @@ type CreationArg = AnyFilePath | string;
 export function createFilePathFromSegments(
 	segments: Array<string>,
 	hint: PathTypeHint,
-): UnknownFilePath {
+): UnknownPath {
 	const parsed = parsePathSegments(segments, hint);
-	return new UnknownFilePath(parsed, createEmptyMemo());
+	return new UnknownPath(parsed, createEmptyMemo());
 }
 
 export function createRelativeFilePath(filename: CreationArg): RelativeFilePath {
-	return createUnknownFilePath(filename, "relative").assertRelative();
+	return createUnknownPath(filename, "relative").assertRelative();
 }
 
-export function createURLFilePath(filename: CreationArg): URLFilePath {
-	return createUnknownFilePath(filename, "auto").assertURL();
+export function createURLPath(filename: CreationArg): URLPath {
+	return createUnknownPath(filename, "auto").assertURL();
 }
 
 export function createAbsoluteFilePath(filename: CreationArg): AbsoluteFilePath {
-	return createUnknownFilePath(filename, "absolute").assertAbsolute();
+	return createUnknownPath(filename, "absolute").assertAbsolute();
 }
 
-export function createUnknownFilePath(
+export function createUnknownPath(
 	filename: CreationArg,
 	hint: PathTypeHint = "auto",
-): UnknownFilePath {
+): UnknownPath {
 	// Allows using the create methods above to be used in places where strings are more ergonomic (eg. in third-party code)
 	if (filename instanceof BaseFilePath) {
 		return filename.toUnknown();
@@ -928,15 +913,15 @@ export function createUnknownFilePath(
 	// Might be better to do a manual loop to detect escaped slashes or some other weirdness
 	const segments = filename.split(/[\\\/]/g);
 	const parsed = parsePathSegments(segments, hint);
-	return new UnknownFilePath(parsed, createEmptyMemo());
+	return new UnknownPath(parsed, createEmptyMemo());
 }
 
 // These are some utility methods so you can pass in `undefined | string`
-export function maybeCreateURLFilePath(
+export function maybeCreateURLPath(
 	filename: undefined | CreationArg,
-): undefined | URLFilePath {
+): undefined | URLPath {
 	if (filename !== undefined) {
-		return createURLFilePath(filename);
+		return createURLPath(filename);
 	} else {
 		return undefined;
 	}
@@ -962,11 +947,11 @@ export function maybeCreateAbsoluteFilePath(
 	}
 }
 
-export function maybeCreateUnknownFilePath(
+export function maybeCreateUnknownPath(
 	filename: undefined | CreationArg,
-): undefined | UnknownFilePath {
+): undefined | UnknownPath {
 	if (filename !== undefined) {
-		return createUnknownFilePath(filename, "auto");
+		return createUnknownPath(filename, "auto");
 	} else {
 		return undefined;
 	}

--- a/internal/path/index.ts
+++ b/internal/path/index.ts
@@ -49,7 +49,7 @@ export type AnyFilePath =
 
 export type PathSegments = Array<string>;
 
-export abstract class BaseFilePath<Super extends AnyFilePath = AnyFilePath> {
+export abstract class BasePath<Super extends AnyFilePath = AnyFilePath> {
 	constructor(parsed: ParsedPath, memo: FilePathMemo<Super>) {
 		this.segments = parsed.segments;
 		this.parsed = parsed;
@@ -507,7 +507,7 @@ export abstract class BaseFilePath<Super extends AnyFilePath = AnyFilePath> {
 	}
 }
 
-export class UnknownPath extends BaseFilePath<UnknownPath> {
+export class UnknownPath extends BasePath<UnknownPath> {
 	protected _fork(
 		parsed: ParsedPath,
 		opts: FilePathMemo<UnknownPath>,
@@ -520,7 +520,7 @@ export class UnknownPath extends BaseFilePath<UnknownPath> {
 	}
 }
 
-export class RelativeFilePath extends BaseFilePath<RelativeFilePath> {
+export class RelativeFilePath extends BasePath<RelativeFilePath> {
 	// TypeScript is structurally typed whereas here we would prefer nominal typing
 	// We use this as a hack.
 	protected type: "relative" = "relative";
@@ -541,7 +541,7 @@ export class RelativeFilePath extends BaseFilePath<RelativeFilePath> {
 	}
 }
 
-export class AbsoluteFilePath extends BaseFilePath<AbsoluteFilePath> {
+export class AbsoluteFilePath extends BasePath<AbsoluteFilePath> {
 	protected type: "absolute" = "absolute";
 
 	private chain: undefined | Array<AbsoluteFilePath>;
@@ -644,7 +644,7 @@ export class AbsoluteFilePath extends BaseFilePath<AbsoluteFilePath> {
 	}
 }
 
-export class URLPath extends BaseFilePath<URLPath> {
+export class URLPath extends BasePath<URLPath> {
 	protected type: "url" = "url";
 
 	protected _assert(): URLPath {
@@ -903,7 +903,7 @@ export function createUnknownPath(
 	hint: PathTypeHint = "auto",
 ): UnknownPath {
 	// Allows using the create methods above to be used in places where strings are more ergonomic (eg. in third-party code)
-	if (filename instanceof BaseFilePath) {
+	if (filename instanceof BasePath) {
 		return filename.toUnknown();
 	}
 

--- a/internal/test-helpers/integration.ts
+++ b/internal/test-helpers/integration.ts
@@ -15,7 +15,7 @@ import {
 	TEMP_PATH,
 	createAbsoluteFilePath,
 	createRelativeFilePath,
-	createUnknownFilePath,
+	createUnknownPath,
 } from "@internal/path";
 
 import {JSONObject, stringifyJSON} from "@internal/codec-json";
@@ -130,7 +130,7 @@ export function findFixtureInput(
 			return {
 				input,
 				handler: getFileHandlerFromPathAssert(
-					createUnknownFilePath(`input.${ext}`),
+					createUnknownPath(`input.${ext}`),
 					projectConfig,
 				).handler,
 			};

--- a/scripts/ast-delete-node.ts
+++ b/scripts/ast-delete-node.ts
@@ -1,7 +1,7 @@
 import {INTERNAL, reporter} from "./_utils";
 import {main as generateAST} from "./generated-files/ast";
 import {removeFile} from "@internal/fs";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {markup} from "@internal/markup";
 
 export async function main([filename]: Array<string>) {
@@ -12,7 +12,7 @@ export async function main([filename]: Array<string>) {
 		return 1;
 	}
 
-	const segments = createUnknownFilePath(filename).getSegments();
+	const segments = createUnknownPath(filename).getSegments();
 	if (segments.length !== 3) {
 		reporter.error(markup`Expected three segments in filename argument`);
 		return 1;

--- a/scripts/generated-files/lint-rules-docs.ts
+++ b/scripts/generated-files/lint-rules-docs.ts
@@ -5,7 +5,7 @@ import {highlightCode} from "@internal/markup-syntax-highlight";
 import {inferDiagnosticLanguageFromFilename} from "@internal/core/common/file-handlers";
 import {concatMarkup, joinMarkupLines, markup} from "@internal/markup";
 import {markupToHtml} from "@internal/cli-layout";
-import {createUnknownFilePath} from "@internal/path";
+import {createUnknownPath} from "@internal/path";
 import {dedent} from "@internal/string-utils";
 import {tests} from "@internal/compiler/lint/rules/tests";
 import {ob1Coerce1} from "@internal/ob1";
@@ -20,7 +20,7 @@ function pre(inner: string): string {
 }
 
 function highlightPre(filename: string, code: string): string {
-	const path = createUnknownFilePath(filename);
+	const path = createUnknownPath(filename);
 	return pre(
 		joinMarkupLines(
 			markupToHtml(


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This renames `URLFilePath` and `UnknownFilePath` to `URLPath` and `UnknownPath`. They don't necessarily refer to files so the new names are more accurate.

This also fixes, or rather hides, the errors relating to when we will reduce an array to empty segments.

The cause of the specific bug I fixed was that `createRelativeFilePath(".").getUnique()` would throw an array as it technically has no segments.

Firstly, what is `getUnique`? `getUnique` is used to compute "unique paths" and it's used in the `PathMap` and `PathSet` collections. Consider the following:

```
const set = new AbsoluteFilePathSet();
set.add(createAbsoluteFilePath("/foo"));
set.add(createAbsoluteFilePath("/foo/"));
```

They both refer to the same actual path, but if we just used the direct `join()` return value, they would be different entries.

For the `.` case specifically, I recently changed it so that these hints, being an explicit directory (as in the example above with a trailing slash), and being explicitly relative (starting with a `./` or `../`), wouldn't result in being displayed as segments. We were previously inserting them as empty segments or adding them to the start. This turned out to cause all sorts of issues since you had to constantly balance different operations. ie. When getting the basename, the last segment of `foo/` would have been `""`, so we would have to check if it was an explicit directory, and increase the offset. Instead, these hints are now properties on an object, so `"."` ends up with no segments but contains a `explicitRelative: true` hint.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Added tests for `path.getUnique`