### PR TITLE
Added test for js-ast-utils/createMemberProperty.ts

### DIFF
--- a/internal/js-ast-utils/createMemberProperty.test.ts
+++ b/internal/js-ast-utils/createMemberProperty.test.ts
@@ -1,0 +1,25 @@
+import {test} from "rome";
+import {createMemberProperty} from "@internal/js-ast-utils/createMemberProperty";
+import {
+	jsComputedMemberProperty,
+	jsIdentifier,
+	jsStaticMemberProperty,
+	jsStringLiteral,
+} from "@internal/ast";
+
+test(
+	"verify createMemberProperty return the correct type",
+	async (t) => {
+		const expectedHello = jsStaticMemberProperty.quick(
+			jsIdentifier.quick("hello"),
+		);
+
+		t.looksLike(createMemberProperty("hello"), expectedHello);
+
+		const expectedTrue = jsComputedMemberProperty.quick(
+			jsStringLiteral.quick("true"),
+		);
+
+		t.looksLike(createMemberProperty("true"), expectedTrue);
+	},
+);


### PR DESCRIPTION
## Summary
Part of #1023 

Adds test for js-ast-utils/createMemberProperty.ts

## Test Plan

`rome check` is successful.
`rome test` passes all tests.