### PR TITLE
test: Add tests for internal/vcs (#1023)

### DIFF
--- a/internal/vcs/index.test.ts
+++ b/internal/vcs/index.test.ts
@@ -1,0 +1,29 @@
+import {test} from "rome";
+import {extractFileList} from "./index";
+
+test(
+	"should extract file names from sample git output",
+	async (t) => {
+		const sampleInput = ` \
+this is a sample string
+only lines containing file names should be captured
+?? file1.txt
+A file2.txt
+M file3.txt
+K file4.txt
+? file5.txt
+?? file6
+??A file7.txt
+?? anything after`;
+
+		const expectedMatch = [
+			"file1.txt",
+			"file2.txt",
+			"file3.txt",
+			"file6",
+			"anything after",
+		];
+
+		t.looksLike(extractFileList(sampleInput), expectedMatch);
+	},
+);

--- a/internal/vcs/index.ts
+++ b/internal/vcs/index.ts
@@ -12,7 +12,7 @@ import {NodeSystemError} from "@internal/node";
 
 const TIMEOUT = 10_000;
 
-function extractFileList(out: string): Array<string> {
+export function extractFileList(out: string): Array<string> {
 	const lines = out.trim().split("\n");
 
 	const files: Array<string> = [];


### PR DESCRIPTION
## Summary
(Ref #1023)

As the code here is mostly dependent on `git`, I only added a test for `extractFileList` for the moment. 

- testing `VCSClient` would require mocking `childProcess.spawn` or spawning a real process with a predetermined output
- testing `GitVCSClient` would require creating a new directory, initializing a new repository and doing a few commits/edits on some temporary files

In both cases, I don't feel that it would worth the effort, as the code is mostly based on external dependencies with a very small chance of getting broken.

I'm waiting for further guidance. 