### PR TITLE
feat: add specific version support to changelog script

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -305,7 +305,7 @@ function updateVersion(releaseType: string, cwd: AbsoluteFilePath): string {
 	).stdout.toString().trim();
 }
 
-export async function main(): Promise<void> {
+export async function main([version]: Array<string>): Promise<void> {
 	// Cache the current version for reverting
 	const currentVersion = await getCurrentVersion();
 
@@ -324,7 +324,7 @@ export async function main(): Promise<void> {
 	);
 
 	// Update the root package version
-	const targetReleaseType = getReleaseType();
+	const targetReleaseType = version || getReleaseType();
 	const newVersion = updateVersion(targetReleaseType, ROOT);
 	reporter.success(
 		markup`The root package version was updated to <emphasis>${newVersion}</emphasis>.`,


### PR DESCRIPTION
## Summary

This pull request updates the existing change log script by adding support for a version argument, allowing a specific version (pre-release or otherwise) to be used instead of the version that's determined internally based on commit history.

This will allow change logs to be generated and tags to be created for future betas by running the script with the correct pre-release specified, e.g. `./rome run scripts/changelog 10.0.5-beta` (cc @sebmck).

## Test Plan

```
./rome run scripts/changelog <some_version>
```
