### PR TITLE
fix: match case insensitive license word (#1064)

### DIFF
--- a/internal/codec-spdx-license/parse.ts
+++ b/internal/codec-spdx-license/parse.ts
@@ -96,12 +96,13 @@ const createSPDXLicenseParser = createParser<SPDXParserTypes>({
 
 		if (isWordChar(char)) {
 			const [value, end] = parser.readInputFrom(index, isWordChar);
+			const upperCasedValue = value.toUpperCase();
 
-			if (value === "AND") {
+			if (upperCasedValue === "AND") {
 				return parser.finishToken("And", end);
-			} else if (value === "OR") {
+			} else if (upperCasedValue === "OR") {
 				return parser.finishToken("Or", end);
-			} else if (value === "WITH") {
+			} else if (upperCasedValue === "WITH") {
 				return parser.finishToken("With", end);
 			} else {
 				return parser.finishValueToken("Word", value, end);


### PR DESCRIPTION
## Summary

Closes #1064

Matches the separator words in the license (such as `or` or `and`) in a case insensitive manner.

## Test Plan

### Folder structure
- **/rome** *(Rome's repository)*
- **/dom-storage.js** *(https://git.coolaj86.com/coolaj86/dom-storage.js/)* 
- **/xmldom** *https://github.com/xmldom/xmldom/()*

### Test 1

#### Commands

- `cd dom-storage.js`
- `../rome/rome init`

#### Output

```

 Welcome to Rome! Let's get you started... 

 Files created ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  - .config/rome.rjson: Your project configuration. Documentation: https://romefrontend.dev/#project-configuration
  - .editorconfig: Sets editor formatting and indentation options. Documentation: https://editorconfig.org/

 What next? ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  1. Setup an editor extension
     Get live errors as you type and format when you save. Learn more: https://romefrontend.dev/#editor-integration

  2. Try a command
     rome check is used to validate your code, verify formatting, and check for lint errors. Run rome --help for a full list of commands and flags.

  3. Read documentation
     Our website serves as a comprehensive source of guides and documentation https://romefrontend.dev/

  4. Get involved in the community
     Ask questions, get support, or contribute by participating on GitHub (https://github.com/romefrontend/rome) or our community Discord (https://discord.gg/rome)

```

### Test 2

#### Commands

- `cd xmldom`
- `git checkout tags/v0.1.31`
- `../rome/rome init`

#### Output

```

 package.json:16:59 parse/manifest ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Unknown web property at contributors[0]

    14 │   "maintainers": [{"name": "jindw","email": "jindw@xidea.org","url": "http://www.xidea.org"}],
    15 │   "contributors": [
  > 16 │     {"name" : "Yaron Naveh","email" : "yaronn01@gmail.com","web" : "http://webservices20.blogspot.com/"},
       │                                                            ^^^^^^
    17 │     {"name" : "Harutyun Amirjanyan","email" : "amirjanyan@gmail.com","web" : "https://github.com/nightwing"},
    18 │     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}

 package.json:17:69 parse/manifest ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Unknown web property at contributors[1]

    15 │   "contributors": [
    16 │     {"name" : "Yaron Naveh","email" : "yaronn01@gmail.com","web" : "http://webservices20.blogspot.com/"},
  > 17 │     {"name" : "Harutyun Amirjanyan","email" : "amirjanyan@gmail.com","web" : "https://github.com/nightwing"},
       │                                                                      ^^^^^^
    18 │     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
    19 │   ],

 package.json:18:65 parse/manifest ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Unknown web property at contributors[2]

    16 │     {"name" : "Yaron Naveh","email" : "yaronn01@gmail.com","web" : "http://webservices20.blogspot.com/"},
    17 │     {"name" : "Harutyun Amirjanyan","email" : "amirjanyan@gmail.com","web" : "https://github.com/nightwing"},
  > 18 │     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
       │                                                                  ^^^^^^
    19 │   ],
    20 │   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

✖ Found 3 problems

```

*(Those errors are expected, this repository is using invalid `package.json` fields. But the errors about the license aren't there anymore)*