### PR TITLE
Add tests for js-ast-utils/tryStaticEvaluation(path)

### DIFF
--- a/internal/js-ast-utils/tryStaticEvaluation.test.ts
+++ b/internal/js-ast-utils/tryStaticEvaluation.test.ts
@@ -26,13 +26,12 @@ test(
 
 		t.false(tryStaticEvaluation(template.expression`~10`, TEST_SCOPE).bailed);
 		t.is(tryStaticEvaluation(template.expression`~10`, TEST_SCOPE).value, -11);
-	},
-);
 
-test(
-	"bails on boolean unary expressions",
-	(t) => {
-		t.true(tryStaticEvaluation(template.expression`!true`, TEST_SCOPE).bailed);
+		t.false(tryStaticEvaluation(template.expression`!true`, TEST_SCOPE).bailed);
+		t.is(
+			tryStaticEvaluation(template.expression`!true`, TEST_SCOPE).value,
+			false,
+		);
 	},
 );
 

--- a/internal/js-ast-utils/tryStaticEvaluation.test.ts
+++ b/internal/js-ast-utils/tryStaticEvaluation.test.ts
@@ -1,0 +1,135 @@
+import {test} from "rome";
+import {tryStaticEvaluation} from "./tryStaticEvaluation";
+import {template} from "./template";
+import {Scope} from "@internal/compiler";
+import {
+	jsReferenceIdentifier,
+	jsTemplateElement,
+	jsTemplateLiteral,
+} from "@internal/ast";
+
+const TEST_SCOPE = new Scope({
+	kind: "program",
+	node: undefined,
+	parentScope: undefined,
+	rootScope: undefined,
+});
+
+test(
+	"successfully evaluates unary expressions that aren't boolean negation",
+	(t) => {
+		t.false(tryStaticEvaluation(template.expression`-5`, TEST_SCOPE).bailed);
+		t.is(tryStaticEvaluation(template.expression`-5`, TEST_SCOPE).value, -5);
+
+		t.false(tryStaticEvaluation(template.expression`+5`, TEST_SCOPE).bailed);
+		t.is(tryStaticEvaluation(template.expression`+5`, TEST_SCOPE).value, 5);
+
+		t.false(tryStaticEvaluation(template.expression`~10`, TEST_SCOPE).bailed);
+		t.is(tryStaticEvaluation(template.expression`~10`, TEST_SCOPE).value, -11);
+	},
+);
+
+test(
+	"bails on boolean unary expressions",
+	(t) => {
+		t.true(tryStaticEvaluation(template.expression`!true`, TEST_SCOPE).bailed);
+	},
+);
+
+test(
+	"successfully evaluates binary expressions",
+	(t) => {
+		t.is(tryStaticEvaluation(template.expression`2 + 5;`, TEST_SCOPE).value, 7);
+
+		t.is(
+			tryStaticEvaluation(template.expression`10 * 5;`, TEST_SCOPE).value,
+			50,
+		);
+
+		t.is(
+			tryStaticEvaluation(template.expression`20 / 2;`, TEST_SCOPE).value,
+			10,
+		);
+
+		t.is(tryStaticEvaluation(template.expression`13 % 5;`, TEST_SCOPE).value, 3);
+
+		t.is(
+			tryStaticEvaluation(template.expression`10 | 6;`, TEST_SCOPE).value,
+			14,
+		);
+
+		t.is(
+			tryStaticEvaluation(template.expression`20 & 20;`, TEST_SCOPE).value,
+			20,
+		);
+
+		t.is(tryStaticEvaluation(template.expression`20 & 2;`, TEST_SCOPE).value, 0);
+
+		t.is(
+			tryStaticEvaluation(template.expression`60 >> 2;`, TEST_SCOPE).value,
+			15,
+		);
+
+		t.is(
+			tryStaticEvaluation(template.expression`100 >>> 3;`, TEST_SCOPE).value,
+			12,
+		);
+
+		t.is(
+			tryStaticEvaluation(template.expression`100 << 2;`, TEST_SCOPE).value,
+			400,
+		);
+
+		t.is(tryStaticEvaluation(template.expression`10 ^ 2;`, TEST_SCOPE).value, 8);
+	},
+);
+
+test(
+	"bails for non-matching binary operators",
+	(t) => {
+		t.true(
+			tryStaticEvaluation(
+				template.expression`listlike instanceof array;`,
+				TEST_SCOPE,
+			).bailed,
+		);
+
+		t.true(
+			tryStaticEvaluation(template.expression`prop in obj;`, TEST_SCOPE).bailed,
+		);
+	},
+);
+
+test(
+	"evaluates template literals",
+	(t) => {
+		const node = jsTemplateLiteral.create({
+			quasis: [
+				jsTemplateElement.create({cooked: "hello ", raw: "hello "}),
+				jsTemplateElement.create({cooked: " world", raw: " world"}),
+			],
+			expressions: [template.expression`2+2;`],
+		});
+		t.false(tryStaticEvaluation(node, TEST_SCOPE).bailed);
+		t.is(tryStaticEvaluation(node, TEST_SCOPE).value, "hello 4 world");
+	},
+);
+
+test(
+	"evaluated reference identifiers",
+	(t) => {
+		t.false(
+			tryStaticEvaluation(
+				jsReferenceIdentifier.create({name: "undefined"}),
+				TEST_SCOPE,
+			).bailed,
+		);
+		t.is(
+			tryStaticEvaluation(
+				jsReferenceIdentifier.create({name: "undefined"}),
+				TEST_SCOPE,
+			).value,
+			undefined,
+		);
+	},
+);

--- a/internal/js-ast-utils/tryStaticEvaluation.ts
+++ b/internal/js-ast-utils/tryStaticEvaluation.ts
@@ -49,6 +49,9 @@ function evalUnaryExpression(
 
 			case "~":
 				return createResult(~value);
+
+			case "!":
+				return createResult(!value);
 		}
 	}
 

--- a/internal/js-ast-utils/tryStaticEvaluationPath.test.ts
+++ b/internal/js-ast-utils/tryStaticEvaluationPath.test.ts
@@ -1,0 +1,26 @@
+import {test} from "rome";
+import {tryStaticEvaluationPath} from "./tryStaticEvaluationPath";
+import {template} from "./template";
+import {CompilerContext, Path, Scope} from "@internal/compiler";
+
+import {MOCK_PROGRAM} from "@internal/ast";
+
+test(
+	"evaluates a node under a path",
+	(t) => {
+		const path = new Path(
+			template.expression`2 + 2 * 10;`,
+			new CompilerContext({ast: MOCK_PROGRAM}),
+			{
+				scope: new Scope({
+					kind: "program",
+					node: undefined,
+					parentScope: undefined,
+					rootScope: undefined,
+				}),
+			},
+		);
+		t.false(tryStaticEvaluationPath(path).bailed);
+		t.is(tryStaticEvaluationPath(path).value, 22);
+	},
+);


### PR DESCRIPTION
## Summary

Part of #1023 

I've added test cases for interal/js-ast-utils/tryStaticEvaluation and tryStaticEvaluationPath. I noticed that boolean negation isn't supported in the unary expression case. ~~I wasn't sure if that was intentional, but I added tests to assert that `!true` would bail.~~ I added support for that after this [Discord message](https://discordapp.com/channels/678763474494423051/678763474930761739/745358222797439076)

## Test Plan

`./rome test` works with more passing tests