### PR TITLE
better errors for non existent languages and categories

### DIFF
--- a/internal/fs/index.ts
+++ b/internal/fs/index.ts
@@ -61,6 +61,7 @@ export type FileHandle = fs.promises.FileHandle;
 export type WriteStream = fs.WriteStream;
 export type ReadStream = fs.ReadStream;
 export type FSWatcher = fs.FSWatcher;
+export type Dir = fs.Dir;
 
 // This file contains some wrappers around Node's fs module. Except here we support passing in AbsoluteFilePath instances.
 // NOTE We don't bother using Node's built-in fs promise functions at all. They already contain a level of indirection to callbacks.

--- a/internal/fs/index.ts
+++ b/internal/fs/index.ts
@@ -61,7 +61,6 @@ export type FileHandle = fs.promises.FileHandle;
 export type WriteStream = fs.WriteStream;
 export type ReadStream = fs.ReadStream;
 export type FSWatcher = fs.FSWatcher;
-export type Dir = fs.Dir;
 
 // This file contains some wrappers around Node's fs module. Except here we support passing in AbsoluteFilePath instances.
 // NOTE We don't bother using Node's built-in fs promise functions at all. They already contain a level of indirection to callbacks.

--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -1,5 +1,10 @@
 import {AbsoluteFilePath, createAbsoluteFilePath} from "@internal/path";
-import {readFileText, writeFile as writeFileReal} from "@internal/fs";
+import {
+	Dir,
+	openDirectory,
+	readFileText,
+	writeFile as writeFileReal,
+} from "@internal/fs";
 import {Reporter} from "@internal/cli-reporter";
 import {createMockWorker} from "@internal/test-helpers";
 
@@ -255,4 +260,47 @@ export async function execDev(args: Array<string>): Promise<void> {
 			},
 		),
 	);
+}
+
+async function getSubDirectories(dir: Dir): Promise<Array<string>> {
+	const subDirs: Array<string> = [];
+
+	for await (const dirent of dir) {
+		if (dirent.isDirectory()) {
+			subDirs.push(dirent.name);
+		}
+	}
+
+	return subDirs;
+}
+
+export async function getLanguages(): Promise<Array<string>> {
+	const astPath = INTERNAL.append("ast");
+	const astDir = await openDirectory(astPath);
+
+	return getSubDirectories(astDir);
+}
+
+export async function getLanguageCategories(
+	language: string,
+): Promise<Array<string>> {
+	const languagePath = INTERNAL.append("ast", language);
+	const languageDir = await openDirectory(languagePath);
+
+	return getSubDirectories(languageDir);
+}
+
+export async function languageExists(language: string): Promise<boolean> {
+	const languages = await getLanguages();
+
+	return languages.includes(language);
+}
+
+export async function languageCategoryExists(
+	language: string,
+	category: string,
+): Promise<boolean> {
+	const categories = await getLanguageCategories(language);
+
+	return categories.includes(category);
 }

--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -1,7 +1,11 @@
-import {AbsoluteFilePath, createAbsoluteFilePath} from "@internal/path";
 import {
-	Dir,
-	openDirectory,
+  AbsoluteFilePath,
+  AbsoluteFilePathSet,
+  createAbsoluteFilePath
+} from "@internal/path";
+import {
+  lstat,
+  readDirectory,
 	readFileText,
 	writeFile as writeFileReal,
 } from "@internal/fs";
@@ -262,12 +266,12 @@ export async function execDev(args: Array<string>): Promise<void> {
 	);
 }
 
-async function getSubDirectories(dir: Dir): Promise<Array<string>> {
+async function getSubDirectories(files: AbsoluteFilePathSet): Promise<Array<string>> {
 	const subDirs: Array<string> = [];
 
-	for await (const dirent of dir) {
-		if (dirent.isDirectory()) {
-			subDirs.push(dirent.name);
+	for await (const file of files) {
+		if((await lstat(file)).isDirectory()) {
+			subDirs.push(file.getBasename());
 		}
 	}
 
@@ -276,7 +280,7 @@ async function getSubDirectories(dir: Dir): Promise<Array<string>> {
 
 export async function getLanguages(): Promise<Array<string>> {
 	const astPath = INTERNAL.append("ast");
-	const astDir = await openDirectory(astPath);
+	const astDir = await readDirectory(astPath);
 
 	return getSubDirectories(astDir);
 }
@@ -285,7 +289,7 @@ export async function getLanguageCategories(
 	language: string,
 ): Promise<Array<string>> {
 	const languagePath = INTERNAL.append("ast", language);
-	const languageDir = await openDirectory(languagePath);
+	const languageDir = await readDirectory(languagePath);
 
 	return getSubDirectories(languageDir);
 }

--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -1,11 +1,11 @@
 import {
-  AbsoluteFilePath,
-  AbsoluteFilePathSet,
-  createAbsoluteFilePath
+	AbsoluteFilePath,
+	AbsoluteFilePathSet,
+	createAbsoluteFilePath,
 } from "@internal/path";
 import {
-  lstat,
-  readDirectory,
+	lstat,
+	readDirectory,
 	readFileText,
 	writeFile as writeFileReal,
 } from "@internal/fs";
@@ -266,11 +266,13 @@ export async function execDev(args: Array<string>): Promise<void> {
 	);
 }
 
-async function getSubDirectories(files: AbsoluteFilePathSet): Promise<Array<string>> {
+async function getSubDirectories(
+	files: AbsoluteFilePathSet,
+): Promise<Array<string>> {
 	const subDirs: Array<string> = [];
 
 	for await (const file of files) {
-		if((await lstat(file)).isDirectory()) {
+		if ((await lstat(file)).isDirectory()) {
 			subDirs.push(file.getBasename());
 		}
 	}

--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -1,4 +1,12 @@
-import {INTERNAL, reporter, writeFile} from "./_utils";
+import {
+	INTERNAL,
+	getLanguageCategories,
+	getLanguages,
+	languageCategoryExists,
+	languageExists,
+	reporter,
+	writeFile,
+} from "./_utils";
 import {exists} from "@internal/fs";
 import {dedent, toCamelCase} from "@internal/string-utils";
 import {markup} from "@internal/markup";
@@ -18,6 +26,36 @@ export async function main(
 		reporter.error(
 			markup`Node type argument "${nodeType}" must have the language prefix "${language}"`,
 		);
+		return 1;
+	}
+
+	if (!(await languageExists(language))) {
+		const languages = await getLanguages();
+
+		reporter.error(
+			markup`Language argument "${language}" is not a valid language`,
+		);
+
+		reporter.info(markup`The following languages are valid:`);
+
+		languages.forEach((languageName) => {
+			reporter.log(markup`${languageName}`);
+		});
+		return 1;
+	}
+
+	if (!(await languageCategoryExists(language, category))) {
+		const categories = await getLanguageCategories(language);
+
+		reporter.error(
+			markup`Category argument "${category}" is not a valid category for "${language}"`,
+		);
+
+		reporter.info(markup`The following categories are valid for ${language}:`);
+
+		categories.forEach((categoryName) => {
+			reporter.log(markup`${categoryName}`);
+		});
 		return 1;
 	}
 

--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -53,7 +53,7 @@ export async function main(
 
 		reporter.info(markup`The following categories are valid for ${language}:`);
 
-		reporter.list(categories.map((categoryName) => markup`${categoryName}`);
+		reporter.list(categories.map((categoryName) => markup`${categoryName}`));
 		return 1;
 	}
 

--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -38,9 +38,7 @@ export async function main(
 
 		reporter.info(markup`The following languages are valid:`);
 
-		languages.forEach((languageName) => {
-			reporter.log(markup`${languageName}`);
-		});
+		reporter.list(languages.map((languageName) => markup`${languageName}`));
 		return 1;
 	}
 

--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -53,9 +53,7 @@ export async function main(
 
 		reporter.info(markup`The following categories are valid for ${language}:`);
 
-		categories.forEach((categoryName) => {
-			reporter.log(markup`${categoryName}`);
-		});
+		reporter.list(categories.map((categoryName) => markup`${categoryName}`);
 		return 1;
 	}
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

This makes the previous output of non existent languages and categories created with `scripts/ast-create-node.ts` more clear.
See #1058 for more.

Output before this change:

`./rome run scripts/ast-create-node js JSDecorator statement`

```
unknown internalError/fs  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ /home/dibenso/source/repos/rome/internal/ast/js/statement/JSDecorator.ts does not exist

  ⚠ No stacktrace available for this error. This is a Node.js limitation: https://github.com/nodejs/node/issues/30944

  ℹ Try setting the ROME_FS_ERRORS=1 envvar to capture stacktraces for fs calls.

  File stats for internal/ast/js

    Object {
      atime: 2020-08-12T16:11:18.887Z
      atimeMs: 1_597_248_678_887.1875
      birthtime: 2020-08-12T16:10:14.200Z
      birthtimeMs: 1_597_248_614_199.7334
      blksize: 4_096
      blocks: 8
      ctime: 2020-08-12T16:10:14.208Z
      ctimeMs: 1_597_248_614_207.7341
      dev: 2_053
      gid: 1_000
      ino: 1_313_744
      isBlockDevice: false
      isCharacterDevice: false
      isDirectory: true
      isFIFO: false
      isFile: false
      isSocket: false
      isSymbolicLink: false
      mode: 16_893
      mtime: 2020-08-12T16:10:14.208Z
      mtimeMs: 1_597_248_614_207.7341
      nlink: 15
      rdev: 0
      size: 4_096
      uid: 1_000
    }

  ⚠ This diagnostic was derived from an internal Rome error. Potential bug, please report if necessary.

```

Output after this change:

`./rome run scripts/ast-create-node jst JSTDecorator statement`
```
✖ Language argument "jst" is not a valid language
ℹ The following languages are valid:
html
js
markdown
css
common
```

and

`./rome run scripts/ast-create-node js JSDecorator statement`
```
✖ Category argument "statement" is not a valid category for "js"
ℹ The following categories are valid for js:
expressions
typescript
modules
statements
jsx
patterns
literals
auxiliary
objects
classes
temp
regex
core
```

## Test Plan
Create an AST node with `scripts/ast-create-node.ts` using non existing languages and / or categories:

`./rome run scripts/ast-create-node jst JSTDecorator statement`
```
✖ Language argument "jst" is not a valid language
ℹ The following languages are valid:
html
js
markdown
css
common
```

and

`./rome run scripts/ast-create-node js JSDecorator statement`
```
✖ Category argument "statement" is not a valid category for "js"
ℹ The following categories are valid for js:
expressions
typescript
modules
statements
jsx
patterns
literals
auxiliary
objects
classes
temp
regex
core
```