### PR TITLE
Fix named pipes path and use better locations for cache, config, data, and runtime directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 Profile-*.json
 .vscode
+.idea

--- a/internal/cli/server.ts
+++ b/internal/cli/server.ts
@@ -7,7 +7,7 @@
 
 import {
 	CLI_SOCKET_PATH,
-	SOCKET_PATH,
+	SERVER_SOCKET_PATH,
 	Server,
 	ServerBridge,
 } from "@internal/core";
@@ -41,12 +41,12 @@ export default async function server() {
 		server.attachToBridge(client);
 	});
 
-	if (await exists(SOCKET_PATH)) {
-		await removeFile(SOCKET_PATH);
+	if (await exists(SERVER_SOCKET_PATH)) {
+		await removeFile(SERVER_SOCKET_PATH);
 	}
 
 	socketServer.listen(
-		SOCKET_PATH.join(),
+		SERVER_SOCKET_PATH.join(),
 		() => {
 			const socket = net.createConnection(
 				CLI_SOCKET_PATH.join(),

--- a/internal/core/client/Client.ts
+++ b/internal/core/client/Client.ts
@@ -14,7 +14,7 @@ import ClientRequest, {ClientRequestType} from "./ClientRequest";
 import Server, {ServerClient, ServerOptions} from "../server/Server";
 import {
 	CLI_SOCKET_PATH,
-	SOCKET_PATH,
+	SERVER_SOCKET_PATH,
 	ServerBridge,
 	ServerQueryResponse,
 	VERSION,
@@ -765,7 +765,7 @@ export default class Client {
 		) => {
 			const socket = net.createConnection(
 				{
-					path: SOCKET_PATH.join(),
+					path: SERVER_SOCKET_PATH.join(),
 				},
 				() => {
 					resolve(socket);

--- a/internal/core/common/constants.ts
+++ b/internal/core/common/constants.ts
@@ -60,7 +60,7 @@ function getEnvironmentDirectory(
 		return undefined;
 	}
 
-	let dir = createAbsoluteFilePath(key);
+	let dir = createAbsoluteFilePath(env);
 	if (append !== undefined) {
 		dir = dir.append(append);
 	}

--- a/internal/core/common/constants.ts
+++ b/internal/core/common/constants.ts
@@ -90,7 +90,6 @@ function getUserConfigDirectory(): AbsoluteFilePath {
 		return getLocalAppDataDir().append("Config");
 	}
 
-	// TODO
 	if (process.platform === "darwin") {
 		return HOME_PATH.append("Library", "Preferences", "Rome");
 	}
@@ -109,7 +108,7 @@ export const DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY = USER_CONFIG_DIRECTORY.appe
 );
 
 // ## Cache
-// TODO
+// User specific non-essential data files
 
 // XDG/Linux: ~/.cache/rome
 // Windows: ~/AppData/Local/Temp/Rome
@@ -135,7 +134,7 @@ function getCacheDirectory(): AbsoluteFilePath {
 export const DEFAULT_CACHE_PATH = getCacheDirectory();
 
 // ## Data
-// TODO
+// User specific data files
 
 // XDG/Linux: ~/.local/share/rome
 // Windows: ~/AppData/Local/Rome/Data

--- a/internal/core/common/constants.ts
+++ b/internal/core/common/constants.ts
@@ -9,7 +9,8 @@ import packageJson from "../../../package.json";
 import {
 	AbsoluteFilePath,
 	HOME_PATH,
-	createAbsoluteFilePath, TEMP_PATH,
+	TEMP_PATH,
+	createAbsoluteFilePath,
 } from "@internal/path";
 import {getEnvVar} from "@internal/cli-environment";
 import os = require("os");
@@ -50,7 +51,10 @@ export const LAG_INTERVAL = 3_000;
 // - https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 // - https://docs.racket-lang.org/basedir/index.html
 
-function getEnvironmentDirectory(key: string, append?: string): undefined | AbsoluteFilePath {
+function getEnvironmentDirectory(
+	key: string,
+	append?: string,
+): undefined | AbsoluteFilePath {
 	const env = process.env[key];
 	if (env === undefined) {
 		return undefined;
@@ -64,7 +68,10 @@ function getEnvironmentDirectory(key: string, append?: string): undefined | Abso
 }
 
 function getLocalAppDataDir(): AbsoluteFilePath {
-	return getEnvironmentDirectory("LOCALAPPDATA", "Rome") ?? HOME_PATH.append("AppData", "Local", "Rome");
+	return (
+		getEnvironmentDirectory("LOCALAPPDATA", "Rome") ??
+		HOME_PATH.append("AppData", "Local", "Rome")
+	);
 }
 
 // ## User config directory
@@ -79,7 +86,7 @@ function getUserConfigDirectory(): AbsoluteFilePath {
 		return XDG_CONFIG_HOME;
 	}
 
-	if (process.platform === 'win32') {
+	if (process.platform === "win32") {
 		return getLocalAppDataDir().append("Config");
 	}
 
@@ -97,7 +104,9 @@ export const USER_CONFIG_FILENAMES: Array<string> = [
 	"config.rjson",
 ];
 
-export const DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY = USER_CONFIG_DIRECTORY.append("recovery");
+export const DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY = USER_CONFIG_DIRECTORY.append(
+	"recovery",
+);
 
 // ## Cache
 // TODO

--- a/internal/core/common/constants.ts
+++ b/internal/core/common/constants.ts
@@ -9,8 +9,7 @@ import packageJson from "../../../package.json";
 import {
 	AbsoluteFilePath,
 	HOME_PATH,
-	TEMP_PATH,
-	createAbsoluteFilePath,
+	createAbsoluteFilePath, TEMP_PATH,
 } from "@internal/path";
 import {getEnvVar} from "@internal/cli-environment";
 import os = require("os");
@@ -24,12 +23,9 @@ export function getBinPath(): AbsoluteFilePath {
 
 const MEGABYTE = 10_000;
 
-// Where we store user configuration, recoverable files etc
-export const USER_CONFIG_DIRECTORY = HOME_PATH.append(".config", "rome");
-export const USER_CONFIG_FILENAMES: Array<string> = [
-	"config.json",
-	"config.rjson",
-];
+// Version constants
+export let VERSION = String(packageJson.version);
+export let REQUIRED_NODE_VERSION_RANGE = String(packageJson.engines.node);
 
 // Constants used to handle scaling
 export const MAX_MASTER_BYTES_BEFORE_WORKERS = 0.5 * MEGABYTE;
@@ -37,20 +33,149 @@ export const MAX_WORKER_BYTES_BEFORE_ADD = MEGABYTE;
 const CPU_COUNT: number = os.cpus().length;
 export const MAX_WORKER_COUNT = Math.min(CPU_COUNT, 4);
 
-// Verson constants
-export let VERSION = String(packageJson.version);
-export let REQUIRED_NODE_VERSION_RANGE = String(packageJson.engines.node);
-
 // Vendor Rome and Trunk Rome could have the same version number if there was no release in between
 // Ensure they are properly namespaced to avoid having daemon socket conflicts
 if (getEnvVar("ROME_DEV").type === "ENABLED") {
 	VERSION += "-dev";
 }
-export const SOCKET_PATH = TEMP_PATH.append(`rome-${VERSION}.sock`);
-export const CLI_SOCKET_PATH = TEMP_PATH.append(`rome-wait-${VERSION}.sock`);
 
 // Misc
 export const MOCKS_DIRECTORY_NAME = "__rmocks__";
 
-// Used as a timeout to indicate if a
+// Used as a heartbeat timeout to indicate if a process is unresponsive
 export const LAG_INTERVAL = 3_000;
+
+// # Folders
+// XDG environment variables information:
+// - https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+// - https://docs.racket-lang.org/basedir/index.html
+
+function getEnvironmentDirectory(key: string, append?: string): undefined | AbsoluteFilePath {
+	const env = process.env[key];
+	if (env === undefined) {
+		return undefined;
+	}
+
+	let dir = createAbsoluteFilePath(key);
+	if (append !== undefined) {
+		dir = dir.append(append);
+	}
+	return dir;
+}
+
+function getLocalAppDataDir(): AbsoluteFilePath {
+	return getEnvironmentDirectory("LOCALAPPDATA", "Rome") ?? HOME_PATH.append("AppData", "Local", "Rome");
+}
+
+// ## User config directory
+// Where we store user configuration, recoverable files etc
+
+// XDG/Linux: ~/.config/rome
+// Windows: ~/AppData/Local/Rome/Config
+// Mac: ~/Library/Preferences/Rome
+function getUserConfigDirectory(): AbsoluteFilePath {
+	const XDG_CONFIG_HOME = getEnvironmentDirectory("XDG_CONFIG_HOME", "rome");
+	if (XDG_CONFIG_HOME !== undefined) {
+		return XDG_CONFIG_HOME;
+	}
+
+	if (process.platform === 'win32') {
+		return getLocalAppDataDir().append("Config");
+	}
+
+	// TODO
+	if (process.platform === "darwin") {
+		return HOME_PATH.append("Library", "Preferences", "Rome");
+	}
+
+	return HOME_PATH.append(".config", "rome");
+}
+
+export const USER_CONFIG_DIRECTORY = getUserConfigDirectory();
+export const USER_CONFIG_FILENAMES: Array<string> = [
+	"config.json",
+	"config.rjson",
+];
+
+export const DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY = USER_CONFIG_DIRECTORY.append("recovery");
+
+// ## Cache
+// TODO
+
+// XDG/Linux: ~/.cache/rome
+// Windows: ~/AppData/Local/Temp/Rome
+// Mac: ~/Library/Caches/Rome
+function getCacheDirectory(): AbsoluteFilePath {
+	const XDG_CACHE_HOME = getEnvironmentDirectory("XDG_CACHE_HOME", "rome");
+	if (XDG_CACHE_HOME !== undefined) {
+		return XDG_CACHE_HOME;
+	}
+
+	if (process.platform === "win32") {
+		// process.env.TEMP also exists, but most apps put caches here
+		return getLocalAppDataDir().append("Cache");
+	}
+
+	if (process.platform === "darwin") {
+		return HOME_PATH.append("Library", "Caches", "Rome");
+	}
+
+	return HOME_PATH.append(".cache", "rome");
+}
+
+export const DEFAULT_CACHE_PATH = getCacheDirectory();
+
+// ## Data
+// TODO
+
+// XDG/Linux: ~/.local/share/rome
+// Windows: ~/AppData/Local/Rome/Data
+// Mac: ~/Library/Rome
+function getDataDirectory(): AbsoluteFilePath {
+	const XDG_DATA_HOME = getEnvironmentDirectory("XDG_DATA_HOME", "rome");
+	if (XDG_DATA_HOME !== undefined) {
+		return XDG_DATA_HOME;
+	}
+
+	if (process.platform === "win32") {
+		return getLocalAppDataDir().append("Data");
+	}
+
+	if (process.platform === "darwin") {
+		return HOME_PATH.append("Library", "Rome");
+	}
+
+	return HOME_PATH.append(".local", "share", "rome");
+}
+
+export const DATA_DIRECTORY = getDataDirectory();
+
+// ## Runtime
+// Ephemeral things like pipes and sockets or other objects restricted to the current run of the program
+// > The directory MUST be owned by the user, and MUST be the only one having read and write access to it.
+// > Its Unix access mode MUST be 0700.
+
+// XDG/Linux: /run/user/$(id -u)
+// Windows: $TEMP/rome
+// Mac: $TEMP/rome
+function getRuntimeDirectory(): AbsoluteFilePath {
+	const XDG_RUNTIME_DIR = getEnvironmentDirectory("XDG_RUNTIME_DIR", "rome");
+	if (XDG_RUNTIME_DIR !== undefined) {
+		return XDG_RUNTIME_DIR;
+	}
+
+	return TEMP_PATH.append("rome");
+}
+
+export const RUNTIME_DIRECTORY = getRuntimeDirectory();
+
+function createPipePath(name: string): AbsoluteFilePath {
+	if (process.platform === "win32") {
+		return createAbsoluteFilePath(String.raw`\\.\pipe\rome-${VERSION}-${name}`);
+	} else {
+		return RUNTIME_DIRECTORY.append(`${VERSION}-wait.sock`);
+	}
+}
+
+export const SERVER_SOCKET_PATH = createPipePath("server");
+export const CLI_SOCKET_PATH = createPipePath("server-wait");

--- a/internal/core/common/userConfig.ts
+++ b/internal/core/common/userConfig.ts
@@ -7,11 +7,12 @@
 
 import {consumeJSON} from "@internal/codec-json";
 import {
+	DEFAULT_CACHE_PATH,
+	DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY,
 	USER_CONFIG_DIRECTORY,
 	USER_CONFIG_FILENAMES,
-	VERSION,
 } from "./constants";
-import {AbsoluteFilePath, TEMP_PATH} from "@internal/path";
+import {AbsoluteFilePath} from "@internal/path";
 import {Consumer} from "@internal/consume";
 import {descriptions} from "@internal/diagnostics";
 import {exists, readFileText} from "@internal/fs";
@@ -25,8 +26,8 @@ export type UserConfig = {
 
 export const DEFAULT_USER_CONFIG: UserConfig = {
 	configPath: undefined,
-	cachePath: TEMP_PATH.append(`rome-${VERSION}`),
-	recoveryPath: USER_CONFIG_DIRECTORY.append("recovery"),
+	cachePath: DEFAULT_CACHE_PATH,
+	recoveryPath: DEFAULT_USER_CONFIG_RECOVERY_DIRECTORY,
 	syntaxTheme: undefined,
 };
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR fixes the path that's used for named pipes on Windows, which is what we use for IPC communication between the CLI and a running server. Named pipes aren't supported on file descriptors which I didn't realize until I carefully read the docs. This will address #1017.

I also took the liberty of improving the locations of the various directories we use, making them align more with their appropriate operating system location. Where possible we always use the value derived from the XDG environment variables, regardless of operating system. See inline comments for additional references and explanation.

**Cache**

XDG/Linux: `~/.cache/rome`
Windows: `~/AppData/Local/Temp/Rome`
Mac: `~/Library/Caches/Rome`

**Config**

XDG/Linux: `~/.config/rome`
Windows: `~/AppData/Local/Rome/Config`
Mac: `~/Library/Preferences/Rome`

**Data**

XDG/Linux: `~/.local/share/rome`
Windows: `~/AppData/Local/Rome/Data`
Mac: `~/Library/Rome`

**Runtime**

XDG/Linux: `/run/user/$(id -u)`
Windows: `$TEMP/rome`
Mac: `$TEMP/rome`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Manually tested on different platforms.