### PR TITLE
Add support for `workspace:` dependency pattern prefix

### DIFF
--- a/internal/codec-js-manifest/dependencies.test.md
+++ b/internal/codec-js-manifest/dependencies.test.md
@@ -91,3 +91,9 @@ npm {
 	}
 }
 ```
+
+## `can parse workspace patterns`
+
+```javascript
+workspace {path: "*"}
+```

--- a/internal/codec-js-manifest/dependencies.test.ts
+++ b/internal/codec-js-manifest/dependencies.test.ts
@@ -44,3 +44,12 @@ test(
 		);
 	},
 );
+
+test(
+	"can parse workspace patterns",
+	async (t) => {
+		t.snapshot(
+			parseDependencyPattern(consumeUnknown("workspace:*", "parse/json"), false),
+		);
+	},
+);

--- a/internal/codec-js-manifest/dependencies.ts
+++ b/internal/codec-js-manifest/dependencies.ts
@@ -27,7 +27,8 @@ export type DependencyPattern =
 	| FilePattern
 	| TagPattern
 	| NpmPattern
-	| LinkPattern;
+	| LinkPattern
+	| WorkspacePattern;
 
 export type ManifestDependencies = Map<ManifestName, DependencyPattern>;
 
@@ -100,7 +101,7 @@ function removePrefix(prefix: string, value: string): string {
 	}
 }
 
-//# GIST
+//# Gist
 
 const GIST_PREFIX = "gist:";
 
@@ -116,7 +117,7 @@ function parseGist(pattern: string): GistPattern {
 	};
 }
 
-//# HOSTED GIT
+//# Hosted Gist
 export type HostedGitHost = "bitbucket" | "github" | "gitlab";
 
 type IncompleteHostedGitPattern = {
@@ -196,7 +197,7 @@ export function getHostedGitURL(pattern: IncompleteHostedGitPattern): string {
 	}
 }
 
-//# REGULAR GIT
+//# Regular Git
 type GitPattern = UrlWithHash & {
 	type: "git";
 };
@@ -216,7 +217,7 @@ function parseGit(pattern: string, consumer: Consumer): GitPattern {
 	};
 }
 
-//# TARBALL
+//# HTTP Tarball
 type HTTPTarballPattern = UrlWithHash & {
 	type: "http-tarball";
 };
@@ -231,7 +232,7 @@ function parseHttpTarball(
 	};
 }
 
-//# SEMVER
+//# Semver Range
 type SemverPattern = {
 	type: "semver";
 	range: SemverRangeNode;
@@ -260,7 +261,7 @@ function parseSemver(
 	};
 }
 
-//# FILE
+//# File
 const FILE_PREFIX_REGEX = /^\.{1,2}\//;
 
 type FilePattern = {
@@ -275,7 +276,7 @@ function parseFile(pattern: string): FilePattern {
 	};
 }
 
-//# TAG
+//# Tag
 
 // This regex will likely need to be refined, not sure what the allowable characters of a tag are
 const TAG_REGEX = /^[a-z]+$/g;
@@ -292,7 +293,22 @@ function parseTag(pattern: string): TagPattern {
 	};
 }
 
-//# LINK
+//# Workspace
+const WORKSPACE_PREFIX = "workspace:";
+
+type WorkspacePattern = {
+	type: "workspace";
+	path: UnknownPath;
+};
+
+function parseWorkspace(pattern: string): WorkspacePattern {
+	return {
+		type: "workspace",
+		path: pattern.slice(WORKSPACE_PREFIX.length),
+	};
+}
+
+//# Link
 const LINK_PREFIX = "link:";
 
 type LinkPattern = {
@@ -307,7 +323,7 @@ function parseLink(pattern: string): LinkPattern {
 	};
 }
 
-//# NPM
+//# Explicit npm
 const NPM_PREFIX = "npm:";
 
 type NpmPattern = {
@@ -449,6 +465,10 @@ export function parseDependencyPattern(
 
 	if (pattern.startsWith("http://") || pattern.startsWith("https://")) {
 		return parseHttpTarball(pattern, consumer);
+	}
+
+	if (pattern.startsWith(WORKSPACE_PREFIX)) {
+		return parseWorkspace(pattern);
 	}
 
 	if (pattern.startsWith(GIST_PREFIX)) {

--- a/internal/codec-js-manifest/dependencies.ts
+++ b/internal/codec-js-manifest/dependencies.ts
@@ -77,6 +77,9 @@ export function stringifyDependencyPattern(pattern: DependencyPattern): string {
 
 		case "link":
 			return `${LINK_PREFIX}${pattern.path.join()}`;
+
+		case "workspace":
+			return `${WORKSPACE_PREFIX}${pattern.path}`;
 	}
 }
 
@@ -298,7 +301,7 @@ const WORKSPACE_PREFIX = "workspace:";
 
 type WorkspacePattern = {
 	type: "workspace";
-	path: UnknownPath;
+	path: string;
 };
 
 function parseWorkspace(pattern: string): WorkspacePattern {
@@ -452,6 +455,9 @@ export function parseGitDependencyPattern(
 	return undefined;
 }
 
+// Check if we received something that looks like a pattern that we don't support
+const UNSUPPORTED_PATTERN = /^([a-z]+):/i;
+
 export function parseDependencyPattern(
 	consumer: Consumer,
 	loose: boolean,
@@ -493,6 +499,11 @@ export function parseDependencyPattern(
 
 	if (pattern.match(TAG_REGEX)) {
 		return parseTag(pattern);
+	}
+
+	const unsupportedMatch = pattern.match(UNSUPPORTED_PATTERN);
+	if (unsupportedMatch != null) {
+		throw consumer.unexpected(descriptions.MANIFEST.UNSUPPORTED_DEPENDENCY_PATTERN_PREFIX(unsupportedMatch[1]));
 	}
 
 	return parseSemver(pattern, consumer, loose);

--- a/internal/codec-js-manifest/dependencies.ts
+++ b/internal/codec-js-manifest/dependencies.ts
@@ -503,7 +503,11 @@ export function parseDependencyPattern(
 
 	const unsupportedMatch = pattern.match(UNSUPPORTED_PATTERN);
 	if (unsupportedMatch != null) {
-		throw consumer.unexpected(descriptions.MANIFEST.UNSUPPORTED_DEPENDENCY_PATTERN_PREFIX(unsupportedMatch[1]));
+		throw consumer.unexpected(
+			descriptions.MANIFEST.UNSUPPORTED_DEPENDENCY_PATTERN_PREFIX(
+				unsupportedMatch[1],
+			),
+		);
 	}
 
 	return parseSemver(pattern, consumer, loose);

--- a/internal/diagnostics/descriptions/manifest.ts
+++ b/internal/diagnostics/descriptions/manifest.ts
@@ -38,6 +38,6 @@ export const manifest = createDiagnosticsCategory({
 		message: markup`${typoKey} is a typo of ${correctKey}`,
 	}),
 	UNSUPPORTED_DEPENDENCY_PATTERN_PREFIX: (prefix: string) => ({
-		message: markup`Unsupported dependency pattern prefix <emphasis>${prefix}</emphasis>`
-	})
+		message: markup`Unsupported dependency pattern prefix <emphasis>${prefix}</emphasis>`,
+	}),
 });

--- a/internal/diagnostics/descriptions/manifest.ts
+++ b/internal/diagnostics/descriptions/manifest.ts
@@ -37,4 +37,7 @@ export const manifest = createDiagnosticsCategory({
 	TYPO: (typoKey: string, correctKey: string) => ({
 		message: markup`${typoKey} is a typo of ${correctKey}`,
 	}),
+	UNSUPPORTED_DEPENDENCY_PATTERN_PREFIX: (prefix: string) => ({
+		message: markup`Unsupported dependency pattern prefix <emphasis>${prefix}</emphasis>`
+	})
 });


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Add support for `workspace:` dependency pattern prefix and add specific error when we're provided with something that looks like an unsupported prefix instead of parsing it as semver.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Added test