### PR TITLE
Test and fixes for internal/markup-syntax-highlight

### DIFF
--- a/internal/markup-syntax-highlight/index.test.ts
+++ b/internal/markup-syntax-highlight/index.test.ts
@@ -1,0 +1,496 @@
+import {TestHelper, test} from "rome";
+import "@internal/core";
+import {createUnknownPath} from "@internal/path";
+import {DiagnosticLanguage} from "@internal/diagnostics";
+import {
+	AnsiHighlightOptions,
+	highlightCode,
+} from "@internal/markup-syntax-highlight";
+import {AnyMarkups} from "@internal/markup/escape";
+
+test(
+	"should highlight JS",
+	testCase(
+		"js",
+		`
+function async foo(bar) {
+	for (let i = 0; i < bar.length; ++i) {
+		if (bar[i] === 123321) {
+			return true;
+		} else (bar[i] === \`template string\`) {
+			return false;
+		} else {
+			return <Compenent attribute="JSX content">Test</Component>;
+		}
+		_something_invalid_
+		/* This is a comment */
+	}
+
+	return (a, b) => { return a + b; };
+}
+`,
+		(<AnyMarkups>[
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="keyword">function</token> <token type="keyword">async</token> <token type="function">foo</token><token type="punctuation">(</token><token type="variable">bar</token><token type="punctuation">)</token> <token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="keyword">for</token> <token type="punctuation">(</token><token type="keyword">let</token> <token type="variable">i</token> <token type="operator">=</token> <token type="number">0</token><token type="punctuation">;</token> <token type="variable">i</token> <token type="operator">\\<</token> <token type="variable">bar</token><token type="punctuation">.</token><token type="variable">length</token><token type="punctuation">;</token> <token type="operator">++</token><token type="variable">i</token><token type="punctuation">)</token> <token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="keyword">if</token> <token type="punctuation">(</token><token type="variable">bar</token><token type="punctuation">[</token><token type="variable">i</token><token type="punctuation">]</token> <token type="operator">===</token> <token type="number">123321</token><token type="punctuation">)</token> <token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t\t<token type="keyword">return</token> <token type="boolean">true</token><token type="punctuation">;</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="punctuation">}</token> <token type="keyword">else</token> <token type="punctuation">(</token><token type="variable">bar</token><token type="punctuation">[</token><token type="variable">i</token><token type="punctuation">]</token> <token type="operator">===</token> <token type="string">`</token><token type="string">template string</token><token type="string">`</token><token type="punctuation">)</token> <token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t\t<token type="keyword">return</token> <token type="boolean">false</token><token type="punctuation">;</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="punctuation">}</token> <token type="keyword">else</token> <token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t\t<token type="keyword">return</token> \\<<token type="variable">Compenent</token> <token type="attr-name">attribute</token><token type="operator">=</token><token type="string">\\"JSX content\\"</token>>Test\\<<token type="operator">/</token><token type="variable">Component</token>><token type="punctuation">;</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="punctuation">}</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="variable">_something_invalid_</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t\t<token type="comment">/* This is a comment */</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="punctuation">}</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="keyword">return</token> <token type="punctuation">(</token><token type="variable">a</token><token type="punctuation">,</token> <token type="variable">b</token><token type="punctuation">)</token> <token type="operator">=></token> <token type="punctuation">{</token> <token type="keyword">return</token> <token type="variable">a</token> <token type="operator">+</token> <token type="variable">b</token><token type="punctuation">;</token> <token type="punctuation">}</token><token type="punctuation">;</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">}</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+		]),
+	),
+);
+
+test(
+	"should highlight HTML",
+	testCase(
+		"html",
+		`
+<img src="https://example.com/image.png"/>
+<p class="test-class another_test_class">This is some text</p>
+<div class="test-class another_test_class">
+	<p class="test-class">This is a nested element</p>
+	This is some nested text
+	<p class="test-class">This is another nested element</p>
+</div>
+`,
+		(<AnyMarkups>[
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">\\<</token><token type="tag">img</token> <token type="attr-name">src</token><token type="attr-equals">=</token><token type="attr-value">\\"https://example.com/image.png\\"</token><token type="punctuation">/></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">\\<</token><token type="tag">p</token> <token type="attr-name">class</token><token type="attr-equals">=</token><token type="attr-value">\\"test-class another_test_class\\"</token><token type="punctuation">></token>This is some text<token type="punctuation">\\</</token><token type="attr-name">p</token><token type="punctuation">></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">\\<</token><token type="tag">div</token> <token type="attr-name">class</token><token type="attr-equals">=</token><token type="attr-value">\\"test-class another_test_class\\"</token><token type="punctuation">></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="punctuation">\\<</token><token type="tag">p</token> <token type="attr-name">class</token><token type="attr-equals">=</token><token type="attr-value">\\"test-class\\"</token><token type="punctuation">></token>This is a nested element<token type="punctuation">\\</</token><token type="attr-name">p</token><token type="punctuation">></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "\tThis is some nested text",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="punctuation">\\<</token><token type="tag">p</token> <token type="attr-name">class</token><token type="attr-equals">=</token><token type="attr-value">\\"test-class\\"</token><token type="punctuation">></token>This is another nested element<token type="punctuation">\\</</token><token type="attr-name">p</token><token type="punctuation">></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">\\</</token><token type="attr-name">div</token><token type="punctuation">></token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+		]),
+	),
+);
+
+test(
+	"should highlight JSON",
+	testCase(
+		"json",
+		`
+{
+	"value": "content",
+	"another_value": 123,
+	"key": true
+	// Line comment
+	/* Block Comment */
+}
+`,
+		(<AnyMarkups>[
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">{</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="string">\\"value\\"</token><token type="operator">:</token> <token type="string">\\"content\\"</token><token type="operator">,</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="string">\\"another_value\\"</token><token type="operator">:</token> <token type="number">123</token><token type="operator">,</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="string">\\"key\\"</token><token type="operator">:</token> <token type="boolean">true</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="comment">// Line comment</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\t<token type="comment">/* Block Comment */</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="punctuation">}</token>',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "",
+					},
+				],
+			},
+		]),
+	),
+);
+
+test(
+	"should highlight SHELL",
+	testCase(
+		"shell",
+		`
+#!/bin/bash 
+export bar="string"
+function foo {
+	ls -la /simple/path
+	ls -la "/path with/spaces" | grep -e "something"
+}
+`,
+		(<AnyMarkups>[
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '<token type="function">',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "#!/bin/bash</token> <dim>",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": 'export</dim> <dim>bar=\\"string\\"',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "function</dim> <dim>foo</dim> <dim>{",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "\tls</dim> <dim>-la</dim> <dim>/simple/path",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": '\tls</dim> <dim>-la</dim> <token type="string">\\"/path</token> <dim>with/spaces\\"</dim> <dim>|</dim> <dim>grep</dim> <dim>-e</dim> <token type="string">\\"something\\"',
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "}",
+					},
+				],
+			},
+			{
+				"type": "MARKUP",
+				"parts": [
+					{
+						"type": "RAW_MARKUP",
+						"value": "</token>",
+					},
+				],
+			},
+		]),
+	),
+);
+
+function testCase(
+	language: DiagnosticLanguage,
+	input: string,
+	expectedOutput: AnyMarkups,
+) {
+	return async (t: TestHelper) => {
+		const highlighted = highlightCode(craftTestInput(input, language));
+		t.looksLike(highlighted, expectedOutput);
+	};
+}
+
+function craftTestInput(input: string, language: DiagnosticLanguage) {
+	return (<AnsiHighlightOptions>{
+		path: createUnknownPath("/unknown"),
+		input,
+		sourceTypeJS: undefined,
+		language,
+		highlight: true,
+	});
+}

--- a/internal/markup-syntax-highlight/utils.test.ts
+++ b/internal/markup-syntax-highlight/utils.test.ts
@@ -1,0 +1,133 @@
+import {test} from "rome";
+import {
+	markupToken,
+	reduceParserCore,
+} from "@internal/markup-syntax-highlight/utils";
+import {ob1Coerce0} from "@internal/ob1";
+import {StaticMarkup} from "@internal/markup";
+import {ReduceCallbackResult} from "./types";
+
+test(
+	"should craft markup for tokens",
+	async (t) => {
+		const tokenInput = makeStaticMarkup([
+			fakeToken,
+			makeRawMarkup(fakeToken),
+			makeStaticMarkup([fakeToken, makeRawMarkup(fakeToken)]),
+		]);
+
+		const expectedMarkupOutput = makeStaticMarkup([
+			expectedMarkupPrefix,
+			makeStaticMarkup([
+				makeStaticMarkup([
+					fakeToken,
+					makeRawMarkup(fakeToken),
+					makeStaticMarkup([fakeToken, makeRawMarkup(fakeToken)]),
+				]),
+			]),
+			expectedMarkupSufix,
+		]);
+
+		t.looksLike(markupToken(validTokenType, tokenInput), expectedMarkupOutput);
+	},
+);
+
+const validTokenType = "keyword";
+const fakeToken = "lorem";
+
+function makeRawMarkup(word: string) {
+	return (<MarkupPart>{
+		type: "RAW_MARKUP",
+		value: word,
+	});
+}
+
+// hacky way of extracting a private type
+const dummyPart = (<StaticMarkup>{
+	type: "MARKUP",
+	parts: [{type: "RAW_MARKUP", value: "lorem"}],
+}).parts[0];
+type MarkupPart = typeof dummyPart;
+
+function makeStaticMarkup(parts: Array<MarkupPart>) {
+	return (<StaticMarkup>{
+		type: "MARKUP",
+		parts,
+	});
+}
+
+const expectedMarkupPrefix = (<MarkupPart>{
+	type: "RAW_MARKUP",
+	value: `<token type=\"${validTokenType}\">`,
+});
+const expectedMarkupSufix = (<MarkupPart>{
+	type: "RAW_MARKUP",
+	value: "</token>",
+});
+
+test(
+	"should identify and markup tokens from input string",
+	async (t) => {
+		const fakeTokensCount = 10;
+		const fakeTokens = Array.from(Array(fakeTokensCount).keys()).map((i) => ({
+			type: `token${i}`,
+			start: ob1Coerce0(i * 7),
+			end: ob1Coerce0(i * 7 + 6),
+		}));
+		const fakeInput = `${fakeTokens.map((token) => token.type).join(" ")} invalid`;
+		const expectedOutput = [
+			makeStaticMarkup([
+				makeRawMarkup(
+					`${fakeTokens.map((token) =>
+						`<token type=\"${validTokenType}\">${token.type}</token>`
+					).join(" ")} <emphasis><color bg="red">invalid</color></emphasis>`,
+				),
+			]),
+		];
+
+		const result = reduceParserCore(
+			fakeInput,
+			[
+				...fakeTokens,
+				{
+					type: "Invalid",
+					start: ob1Coerce0(fakeTokensCount * 7),
+					end: ob1Coerce0(fakeTokensCount * 7 + 7),
+				},
+				{
+					type: "EOF",
+					start: ob1Coerce0(fakeTokensCount * 7 + 8),
+					end: ob1Coerce0(fakeTokensCount * 7 + 9),
+				},
+			],
+			(token, value, prev, next) => {
+				const tokenId = parseInt(token.type[token.type.length - 1]);
+				const prevTokenId =
+					prev === undefined
+						? undefined
+						: parseInt(prev.type[prev.type.length - 1]);
+				const nextTokenId =
+					next === undefined
+						? undefined
+						: parseInt(next.type[next.type.length - 1]);
+
+				if (tokenId === 0) {
+					t.is(prevTokenId, undefined);
+					t.is(nextTokenId, 1);
+				} else if (tokenId === fakeTokensCount - 1) {
+					t.is(prevTokenId, fakeTokensCount - 2);
+					t.is(next!.type, "Invalid");
+				} else {
+					t.is(prevTokenId, tokenId - 1);
+					t.is(nextTokenId, tokenId + 1);
+				}
+
+				return (<ReduceCallbackResult>{
+					type: validTokenType,
+					value: makeStaticMarkup([value]),
+				});
+			},
+		);
+		t.looksLike(result, expectedOutput);
+	},
+);

--- a/internal/markup-syntax-highlight/utils.ts
+++ b/internal/markup-syntax-highlight/utils.ts
@@ -38,8 +38,8 @@ export function reduce<Token extends TokenShape>(
 		// Print this token
 		// We need to break up the token text into lines, so that we can easily split the highlighted newlines and have the ansi codes be unbroken
 		const lines = splitLines(value);
-		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
+		for (let j = 0; j < lines.length; j++) {
+			const line = lines[j];
 
 			if (line !== "") {
 				const prev = tokens[i - 1];
@@ -59,7 +59,7 @@ export function reduce<Token extends TokenShape>(
 			}
 
 			// Last element isn't a line break
-			const isLast = i === lines.length - 1;
+			const isLast = j === lines.length - 1;
 			if (!isLast) {
 				parts.push(markup`\n`);
 			}


### PR DESCRIPTION
## Summary
Ref #1023 

- [X] `utils.ts` - written unit tests for `reduceParserCore` (which includes `reduce`) and `markupToken`; `concatSplitLinesMarkup` and `invalidHighlight` are too simple and already included in the previous functions to be individually tested 
- [x] `index.ts`
- [x] `highlight{JSON, HTML, TS, Shell}.ts`