### PR TITLE
Document global install in Getting Started so that CLI command works

### DIFF
--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -5,13 +5,13 @@
 Rome is available for installation via [Yarn](https://yarnpkg.com/):
 
 ```bash
-yarn add rome
+yarn global add rome
 ```
 
 or [npm](https://www.npmjs.com/):
 
 ```bash
-npm install rome
+npm install -g rome
 ```
 
 ### Creating a Project


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The currently document install commands install the package locally to a specific project, which means that:
1. Rome isn't globally available
2. The command isn't in the path


