### PR TITLE
Automaticaly add `rome` to `dependencies` when running `rome init`

### DIFF
--- a/internal/async/lockers.ts
+++ b/internal/async/lockers.ts
@@ -6,6 +6,9 @@
  */
 
 import {AnyFilePath} from "@internal/path";
+import {VoidCallback} from "@internal/typescript-helpers";
+import {createDeferredPromise} from "@internal/async/index";
+import {Event} from "@internal/events";
 
 type LockResolve<RawKey, MapKey> = (lock: Lock<RawKey, MapKey>) => void;
 
@@ -103,26 +106,78 @@ abstract class LockerNormalized<RawKey, MapKey> {
 	}
 }
 
+export type UnknownLocker = LockerNormalized<unknown, unknown>;
+
 export class Locker<Key> extends LockerNormalized<Key, Key> {
 	protected normalizeKey(key: Key): Key {
 		return key;
 	}
 }
 
-export class SingleLocker extends LockerNormalized<void, void> {
-	protected normalizeKey(key: void): void {
-		return key;
-	}
-
-	public async wrapSingleLock(
-		callback: () => void | Promise<void>,
-	): Promise<void> {
-		return this.wrapLock(undefined, callback);
-	}
-}
-
 export class FilePathLocker extends LockerNormalized<AnyFilePath, string> {
 	protected normalizeKey(path: AnyFilePath): string {
 		return path.join();
+	}
+}
+
+export class GlobalLock {
+	constructor() {
+		this.resolves = [];
+		this.dependencies = 0;
+
+		this.incrementEvent = new Event({
+			name: "incrementEvent",
+		});
+
+		this.decrementEvent = new Event({
+			name: "decrementEvent",
+		});
+	}
+
+	private incrementEvent: Event<void, void>;
+	private decrementEvent: Event<void, void>;
+	private resolves: Array<VoidCallback>;
+	private dependencies: number;
+
+	attachLock(lock: GlobalLock) {
+		lock.incrementEvent.subscribe(() => {
+			this.dependencies++;
+		});
+
+		lock.decrementEvent.subscribe(() => {
+			this.dependencies--;
+
+			if (this.dependencies === 0) {
+				this.unlock();
+			}
+		});
+	}
+
+	private unlock() {
+		for (const resolve of this.resolves) {
+			resolve();
+		}
+		this.resolves = [];
+	}
+
+	public async wrap<T>(fn: () => Promise<T>): Promise<T> {
+		try {
+			this.dependencies++;
+			return await fn();
+		} finally {
+			this.dependencies--;
+
+			if (this.dependencies === 0) {
+				this.unlock();
+			}
+		}
+	}
+
+	public async wait() {
+		if (this.dependencies > 0) {
+			const {resolve, promise} = createDeferredPromise();
+			this.resolves.push(resolve);
+			await promise;
+		}
 	}
 }

--- a/internal/cli-reporter/types.ts
+++ b/internal/cli-reporter/types.ts
@@ -9,7 +9,11 @@ import {Event} from "@internal/events";
 import {TerminalFeatures} from "@internal/cli-environment";
 import {AnyMarkup, AnyMarkups, StaticMarkup} from "@internal/markup";
 import {Number0} from "@internal/ob1";
-import {VoidCallback} from "@internal/typescript-helpers";
+import {
+	AsyncCallback,
+	AsyncVoidCallback,
+	VoidCallback,
+} from "@internal/typescript-helpers";
 
 export type SelectOption = {
 	label: StaticMarkup;
@@ -30,6 +34,12 @@ export type SelectArguments<Options extends SelectOptions> = {
 	defaults?: Array<SelectOptionsKeys<Options>>;
 	radio?: boolean;
 	yes?: boolean;
+};
+
+export type ReporterStepCallback = {
+	message: AnyMarkup;
+	test?: AsyncCallback<boolean>;
+	callback: AsyncVoidCallback;
 };
 
 export interface ReporterListOptions {

--- a/internal/codec-js-manifest/convert.ts
+++ b/internal/codec-js-manifest/convert.ts
@@ -132,10 +132,7 @@ function dependencyMapToObject(
 
 	const obj: Dict<string> = {};
 	for (const [name, pattern] of map) {
-		const key = manifestNameToString(name);
-		if (key !== undefined) {
-			obj[key] = stringifyDependencyPattern(pattern);
-		}
+		obj[name] = stringifyDependencyPattern(pattern);
 	}
 	return obj;
 }

--- a/internal/codec-js-manifest/dependencies.ts
+++ b/internal/codec-js-manifest/dependencies.ts
@@ -13,7 +13,7 @@ import {
 } from "@internal/codec-semver";
 import {tryParseWithOptionalOffsetPosition} from "@internal/parser-core";
 import {UnknownPath, createUnknownPath} from "@internal/path";
-import {normalizeName} from "./name";
+import {manifestNameToString, normalizeName} from "./name";
 import {ob1Add} from "@internal/ob1";
 import {descriptions} from "@internal/diagnostics";
 import {ManifestName} from "./types";
@@ -29,7 +29,7 @@ export type DependencyPattern =
 	| NpmPattern
 	| LinkPattern;
 
-export type ManifestDependencies = Map<ManifestName, DependencyPattern>;
+export type ManifestDependencies = Map<string, DependencyPattern>;
 
 type UrlWithHash = {
 	url: string;
@@ -497,7 +497,7 @@ export function normalizeDependencies(
 	}
 
 	for (const [rawName, value] of consumer.asMap()) {
-		const name = normalizeName({
+		const nameObj = normalizeName({
 			name: rawName,
 			loose,
 			unexpected: ({description, at}) => {
@@ -511,7 +511,10 @@ export function normalizeDependencies(
 			},
 		});
 
-		map.set(name, parseDependencyPattern(value, loose));
+		const name = manifestNameToString(nameObj);
+		if (name !== undefined) {
+			map.set(name, parseDependencyPattern(value, loose));
+		}
 	}
 
 	return map;

--- a/internal/codec-js-manifest/index.ts
+++ b/internal/codec-js-manifest/index.ts
@@ -672,7 +672,7 @@ export async function normalizeManifest(consumer: Consumer): Promise<Manifest> {
 			...normalizeStringArray(consumer.get("bundleDependencies"), loose),
 		],
 		// People fields
-		author: consumer.has("author")
+		author: consumer.has("author") && !consumer.get("author").isEmpty()
 			? normalizePerson(consumer.get("author"), loose)
 			: undefined,
 		contributors: normalizePeople(consumer.get("contributors"), loose),

--- a/internal/codec-js-manifest/index.ts
+++ b/internal/codec-js-manifest/index.ts
@@ -27,12 +27,8 @@ import {
 } from "./types";
 import {tryParseWithOptionalOffsetPosition} from "@internal/parser-core";
 import {normalizeName} from "./name";
-import {Diagnostics, descriptions} from "@internal/diagnostics";
-import {
-	AbsoluteFilePath,
-	RelativeFilePathMap,
-	createRelativeFilePath,
-} from "@internal/path";
+import {descriptions} from "@internal/diagnostics";
+import {RelativeFilePathMap, createRelativeFilePath} from "@internal/path";
 import {toCamelCase} from "@internal/string-utils";
 import {PathPatterns, parsePathPattern} from "@internal/path-match";
 import {normalizeCompatManifest} from "@internal/codec-js-manifest/compat";
@@ -616,21 +612,10 @@ function checkDependencyKeyTypo(key: string, prop: Consumer) {
 	}
 }
 
-export async function normalizeManifest(
-	path: AbsoluteFilePath,
-	rawConsumer: Consumer,
-): Promise<{
-	manifest: Manifest;
-	diagnostics: Diagnostics;
-}> {
-	const loose = path.getSegments().includes("node_modules");
-
-	const {consumer, diagnostics} = rawConsumer.capture();
-
-	// FIXME: There's this ridiculous node module that includes it's tests... which deliberately includes an invalid package.json
-	if (path.join().includes("resolve/test/resolver/invalid_main")) {
-		consumer.setValue({});
-	}
+export async function normalizeManifest(consumer: Consumer): Promise<Manifest> {
+	const loose =
+		consumer.path !== undefined &&
+		consumer.path.getSegments().includes("node_modules");
 
 	// Check for typos. Ignore them in loose mode.
 	if (!loose) {
@@ -653,7 +638,7 @@ export async function normalizeManifest(
 		normalizeCompatManifest(consumer, name, version);
 	}
 
-	const manifest: Manifest = {
+	return {
 		name,
 		version,
 		private: normalizeBoolean(consumer, "private") === true,
@@ -693,10 +678,5 @@ export async function normalizeManifest(
 		contributors: normalizePeople(consumer.get("contributors"), loose),
 		maintainers: normalizePeople(consumer.get("maintainers"), loose),
 		raw: consumer.asJSONObject(),
-	};
-
-	return {
-		manifest,
-		diagnostics,
 	};
 }

--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -789,11 +789,7 @@ export default class ServerRequest {
 		factory: (bridge: WorkerBridge, ref: FileReference) => Promise<T>,
 		opts: WrapRequestDiagnosticOpts = {},
 	): Promise<T> {
-		// Wait on any evicting projects in case it will change the FileReference
-		const {evictingProjectLock} = this.server.projectManager;
-		if (evictingProjectLock.hasLock()) {
-			await this.server.projectManager.evictingProjectLock.waitLockDrained();
-		}
+		await this.server.memoryFs.processingLock.wait();
 
 		const {server} = this;
 		const owner = await server.fileAllocator.getOrAssignOwner(path);

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -649,10 +649,8 @@ export default class MemoryFileSystem {
 			consumeDiagnosticCategory: "parse/manifest",
 		});
 
-		const {
-			manifest,
-			diagnostics: normalizedDiagnostics,
-		} = await normalizeManifest(path, consumer);
+		const {consumer: normalizeConsumer, diagnostics: normalizedDiagnostics} = consumer.capture();
+		const manifest = await normalizeManifest(normalizeConsumer);
 
 		// If manifest is undefined then we failed to validate and have diagnostics
 		if (normalizedDiagnostics.length > 0) {

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -39,6 +39,7 @@ import {markup} from "@internal/markup";
 import {ReporterNamespace} from "@internal/cli-reporter";
 import {GlobOptions, Globber} from "./glob";
 import {VoidCallback} from "@internal/typescript-helpers";
+import {GlobalLock} from "@internal/async";
 
 // Paths that we will under no circumstance want to include
 const DEFAULT_DENYLIST = [
@@ -144,11 +145,16 @@ export default class MemoryFileSystem {
 		this.changedFileEvent = new EventQueue();
 		this.deletedFileEvent = new EventQueue();
 		this.newFileEvent = new EventQueue();
+
+		this.processingLock = new GlobalLock();
+		this.processingLock.attachLock(this.changedFileEvent.lock);
+		this.processingLock.attachLock(this.deletedFileEvent.lock);
 	}
 
 	public changedFileEvent: EventQueue<ChangedFileEventItem>;
 	public deletedFileEvent: EventQueue<AbsoluteFilePath>;
 	public newFileEvent: EventQueue<AbsoluteFilePath>;
+	public processingLock: GlobalLock;
 
 	private manifestCounter: number;
 	private watcherCounter: number;
@@ -198,15 +204,6 @@ export default class MemoryFileSystem {
 				}
 			}
 		}
-	}
-
-	public async flushFileEvents() {
-		const {server} = this;
-		await server.refreshFileEvent.flush();
-		await this.newFileEvent.flush();
-		await this.changedFileEvent.flush();
-		await this.deletedFileEvent.flush();
-		await server.projectManager.evictingProjectLock.waitLockDrained();
 	}
 
 	public hasBuffer(path: AbsoluteFilePath): boolean {
@@ -533,15 +530,17 @@ export default class MemoryFileSystem {
 		const promise = this.createWatcher(diagnostics, projectDirectory, id);
 		this.watchPromises.set(projectDirectory, promise);
 
-		const watcherClose = await promise;
-		this.watchers.set(
-			projectDirectory,
-			{
-				path: projectDirectory,
-				close: watcherClose,
-			},
-		);
-		this.watchPromises.delete(projectDirectory);
+		await this.processingLock.wrap(async () => {
+			const watcherClose = await promise;
+			this.watchers.set(
+				projectDirectory,
+				{
+					path: projectDirectory,
+					close: watcherClose,
+				},
+			);
+			this.watchPromises.delete(projectDirectory);
+		});
 
 		diagnostics.maybeThrowDiagnosticsError();
 	}

--- a/internal/core/server/fs/RecoveryStore.ts
+++ b/internal/core/server/fs/RecoveryStore.ts
@@ -569,7 +569,7 @@ export default class RecoveryStore {
 			for (const teardown of teardowns) {
 				await teardown();
 			}
-			await this.server.memoryFs.flushFileEvents();
+			await this.server.memoryFs.processingLock.wait();
 		}
 
 		return fileCount;

--- a/internal/core/server/fs/glob.ts
+++ b/internal/core/server/fs/glob.ts
@@ -11,7 +11,7 @@ import {
 	parsePathPattern,
 } from "@internal/path-match";
 import MemoryFileSystem from "@internal/core/server/fs/MemoryFileSystem";
-import {SingleLocker} from "@internal/async/lockers";
+import {GlobalLock} from "@internal/async";
 
 const GLOB_IGNORE: PathPatterns = [parsePathPattern({input: "node_modules"})];
 
@@ -184,7 +184,7 @@ class GlobberWatcher {
 
 		this.callback = callback;
 		this.args = args;
-		this.flushLock = new SingleLocker();
+		this.flushLock = new GlobalLock();
 
 		this.batchPaths = undefined;
 	}
@@ -196,7 +196,7 @@ class GlobberWatcher {
 
 	private batchPaths: undefined | AbsoluteFilePathSet;
 	private callback: WatchFilesCallback;
-	private flushLock: SingleLocker;
+	private flushLock: GlobalLock;
 
 	isDependentPath(path: AbsoluteFilePath): boolean {
 		for (const arg of this.args) {
@@ -227,20 +227,17 @@ class GlobberWatcher {
 	}
 
 	async flush(paths: AbsoluteFilePathSet, initial: boolean = false) {
-		const lock = await this.flushLock.getLock();
-		try {
+		await this.flushLock.wrap(async () => {
 			// We could be evicting a project as the result of a modification made inside of the watch callback
 			// Ensure it's complete before we decide to flush
-			await this.server.projectManager.evictingProjectLock.waitLockDrained();
+			await this.server.memoryFs.processingLock.wait();
 
 			if (paths.size === 0 && !initial) {
 				return;
 			}
 
 			await this.callback({paths, initial});
-		} finally {
-			lock.release();
-		}
+		});
 	}
 
 	setupEvents(): Array<EventSubscription> {
@@ -270,7 +267,7 @@ class GlobberWatcher {
 			...subs,
 			{
 				unsubscribe: async () => {
-					await this.flushLock.waitLockDrained();
+					await this.flushLock.wait();
 				},
 			},
 		]);

--- a/internal/diagnostics/categories.ts
+++ b/internal/diagnostics/categories.ts
@@ -15,6 +15,7 @@ export type DiagnosticCategory =
 	| "args/invalid"
 	| "bundler/moduleCycle"
 	| "bundler/topLevelAwait"
+	| "childProcess/failure"
 	| "commands/init/uncommittedChanges"
 	| "commands/init/expectedRepo"
 	| "compile/classes"

--- a/internal/diagnostics/types.ts
+++ b/internal/diagnostics/types.ts
@@ -64,6 +64,7 @@ export type DiagnosticLanguage =
 	| "css"
 	| "html"
 	| "md"
+	| "text"
 	| "unknown";
 
 export type DiagnosticSourceType = "unknown" | ConstJSSourceType;

--- a/internal/fs/index.ts
+++ b/internal/fs/index.ts
@@ -140,6 +140,19 @@ export async function readFileText(path: AbsoluteFilePath): Promise<string> {
 	return (await readFile(path)).toString();
 }
 
+// Return value is meant to be consumed via ParserOptions
+export async function readFileTextMeta(
+	path: AbsoluteFilePath,
+): Promise<{
+	path: AbsoluteFilePath;
+	input: string;
+}> {
+	return {
+		input: (await readFile(path)).toString(),
+		path,
+	};
+}
+
 // writeFile
 export function writeFile(
 	path: AbsoluteFilePath,

--- a/internal/typescript-helpers/index.ts
+++ b/internal/typescript-helpers/index.ts
@@ -11,9 +11,14 @@ export type VoidCallback<Args extends Array<unknown> = []> = Args extends []
 	? ((arg?: VoidReturn) => VoidReturn)
 	: ((...args: Args) => VoidReturn);
 
-export type AsyncVoidCallback<Args extends Array<unknown> = []> = Args extends []
-	? ((arg?: VoidReturn) => VoidReturn | Promise<VoidReturn>)
-	: ((...args: Args) => VoidReturn | Promise<VoidReturn>);
+export type AsyncVoidCallback<Args extends Array<unknown> = []> = AsyncCallback<
+	VoidReturn,
+	Args
+>;
+
+export type AsyncCallback<Return, Args extends Array<unknown> = []> = Args extends []
+	? (() => Return | Promise<Return>)
+	: ((...args: Args) => Return | Promise<Return>);
 
 export type ErrorCallback<Err extends Error = Error> = (err: Err) => void;
 
@@ -24,9 +29,22 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 	? I
 	: never;
 
-export type Class<T, Args extends Array<unknown> = Array<unknown>> = new (
-	...args: Args
-) => T;
+// rome-ignore lint/ts/noExplicitAny lint/js/noUndeclaredVariables
+type ClassConstructorParams<T> = T extends {
+	new (
+		...args: infer R
+	): any;
+}
+	? R
+	: never;
+
+// rome-ignore lint/ts/noExplicitAny
+export interface Class<T, Args extends Array<any> = ClassConstructorParams<T>> {
+	new (
+		...args: Args
+	): T;
+	prototype: T;
+}
 
 export type Dict<T> = Record<string, T>;
 

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1,6 +1,6 @@
 import {markup} from "@internal/markup";
 import {parseCommit} from "@internal/commit-parser";
-import {readFileText} from "@internal/fs";
+import {readFileTextMeta} from "@internal/fs";
 import {AbsoluteFilePath} from "@internal/path";
 import {PUBLIC_PACKAGES, ROOT, reporter, writeFile} from "./_utils";
 import {dedent} from "@internal/string-utils";
@@ -142,7 +142,7 @@ ${list}
  */
 async function getCurrentVersion(): Promise<string> {
 	const path = ROOT.append("package.json");
-	return consumeJSON({input: await readFileText(path), path}).get("version").asString();
+	return consumeJSON(await readFileTextMeta(path)).get("version").asString();
 }
 
 /**


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR makes `rome init` automatically add itself as a dependency to `package.json` when ran in a folder without installed. This allows `npx rome init` to function as a single safe command.

In the process of doing this I had to fix numerous long-standing race conditions around `package.json` updates, which was necessary here as we are modifying `package.json` to include `rome` in an already created project. (#751) I did this by adding a global memory file system lock that we wait on in strategic places.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Manually tested, ran test suite.