### PR TITLE
"throw" is type JSThrowStatement, not UnaryExpression

### DIFF
--- a/internal/ast/js/expressions/JSUnaryExpression.ts
+++ b/internal/ast/js/expressions/JSUnaryExpression.ts
@@ -15,15 +15,7 @@ export interface JSUnaryExpression extends NodeBaseWithComments {
 	readonly argument: AnyJSExpression;
 }
 
-export type UnaryOperator =
-	| "-"
-	| "+"
-	| "!"
-	| "~"
-	| "typeof"
-	| "void"
-	| "delete"
-	| "throw";
+export type UnaryOperator = "-" | "+" | "!" | "~" | "typeof" | "void" | "delete";
 
 export const jsUnaryExpression = createBuilder<JSUnaryExpression>(
 	"JSUnaryExpression",

--- a/internal/js-analysis/evaluators/expressions/JSUnaryExpression.ts
+++ b/internal/js-analysis/evaluators/expressions/JSUnaryExpression.ts
@@ -35,10 +35,6 @@ export default function JSUnaryExpression(node: AnyNode, scope: Scope) {
 		// void
 		case "void":
 			return new VoidT(scope, node);
-
-		// empty!
-		case "throw":
-			break;
 	}
 
 	return undefined;


### PR DESCRIPTION
## Summary
[While writing unit tests for `isUnaryLike`, throw wasn't a UnaryExpression.](https://github.com/romefrontend/rome/issues/1023#issuecomment-673769870) 
Remove it from the UnaryExpression definitions!

Related to [Missing Tests #1023](https://github.com/romefrontend/rome/issues/1023)  

This PR has not been made with contextual knowledge, just what seems correct from a narrow look at the code in `internal/ast/js/expressions/JSUnaryExpression.ts`. 

## Test Plan
I've depended on the existing test suite for testing. I'm happy to do more but will need direction. 