### PR TITLE
fix(website): a11y language support table

### DIFF
--- a/website/src/_includes/docs/intro.md
+++ b/website/src/_includes/docs/intro.md
@@ -42,11 +42,11 @@ We plan on covering the following areas:
 
 | Language | Parsing | Formatting | Linting |
 | - | - | - | - |
-| JavaScript | ✅ | ✅ | ✅ |
-| &mdash; TypeScript | ✅ | ✅ | ✅ |
-| &mdash; JSX  | ✅ | ✅ | ✅ |
-| JSON | ✅ | ✅ | |
-| &mdash; [RJSON](#rome-json) | ✅ | ✅ | |
-| HTML [#983](https://github.com/romefrontend/rome/issues/983) | <span aria-label="Work in Progress">⌛</span> | <span aria-label="Work in Progress">⌛</span> | <span aria-label="Work in Progress">⌛</span> |
-| CSS [#984](https://github.com/romefrontend/rome/issues/984) | ✅ | <span aria-label="Work in Progress">⌛</span> | <span aria-label="Work in Progress">⌛</span> |
-| Markdown [#985](https://github.com/romefrontend/rome/issues/985) | <span aria-label="Work in Progress">⌛</span> | <span aria-label="Work in Progress">⌛</span> | <span aria-label="Work in Progress">⌛</span> |
+| JavaScript | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> |
+| &mdash; TypeScript | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> |
+| &mdash; JSX  | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> |
+| JSON | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> |
+| &mdash; [RJSON](#rome-json) | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Supported" role="img">✅</span> |
+| HTML [#983](https://github.com/romefrontend/rome/issues/983) | <span aria-label="Work in Progress" role="img">⌛</span> | <span aria-label="Work in Progress" role="img">⌛</span> | <span aria-label="Work in Progress" role="img">⌛</span> |
+| CSS [#984](https://github.com/romefrontend/rome/issues/984) | <span aria-label="Supported" role="img">✅</span> | <span aria-label="Work in Progress" role="img">⌛</span> | <span aria-label="Work in Progress" role="img">⌛</span> |
+| Markdown [#985](https://github.com/romefrontend/rome/issues/985) | <span aria-label="Work in Progress" role="img">⌛</span> | <span aria-label="Work in Progress" role="img">⌛</span> | <span aria-label="Work in Progress" role="img">⌛</span> |


### PR DESCRIPTION
This is part of a series of PRs concerning **📎 Website accessibility audit** (https://github.com/romefrontend/rome/issues/839#issuecomment-672338554)

This PR fixes: 

Language support table: empty cells are confusing even for non-impaired readers and the ones with emojis are not correctly read by screen readers.

There are not too many visual changes, but I've included some images to illustrate.

### Before

![Screenshot_2020-08-12 Rome Frontend Toolchain](https://user-images.githubusercontent.com/8527573/90963975-01381700-e493-11ea-8860-a20f16d9de67.png)

### After

![Screenshot_2020-08-22 Rome Frontend Toolchain](https://user-images.githubusercontent.com/8527573/90963976-02694400-e493-11ea-9701-08121158f6ab.png)
