### PR TITLE
fix: export AST interface

### DIFF
--- a/scripts/ast-create-node.ts
+++ b/scripts/ast-create-node.ts
@@ -72,7 +72,7 @@ export async function main(
 			import {NodeBaseWithComments} from "@internal/ast";
 			import {createBuilder} from "../../utils";
 
-			interface ${nodeType} extends NodeBaseWithComments {
+			export interface ${nodeType} extends NodeBaseWithComments {
 				readonly type: "${nodeType}";
 			}
 


### PR DESCRIPTION
## Summary

I've noticed if one uses the `ast-create-node` script the interface is not exported which causes an error in `internal/ast/js/unions.ts` file. This PR fixes it.

## Test Plan

To check that the error is valid, run the `ast-create-node` script to create a new expression node and then check for errors with `./node_modules/.bin/tsc`. After adding this change the error is no longer present.
