### PR TITLE
Added test for js-ast-utils/getTSQualifiedBaseFromEntityName.ts

### DIFF
--- a/internal/js-ast-utils/getTSQualifiedBaseFromEntityName.test.ts
+++ b/internal/js-ast-utils/getTSQualifiedBaseFromEntityName.test.ts
@@ -1,0 +1,40 @@
+import {test} from "rome";
+import {parseJS} from "../js-parser";
+import {dedent} from "../string-utils";
+import {getTSQualifiedBaseFromEntityName} from "./getTSQualifiedBaseFromEntityName";
+import {
+	jsExpressionStatement,
+	jsReferenceIdentifier,
+	tsImportEqualsDeclaration,
+	tsQualifiedName,
+} from "../ast";
+
+test(
+	"verify reference returned by getTSQualifiedBaseFromEntityName",
+	async (t) => {
+		const js = parseJS({
+			path: "unknown",
+			input: dedent`
+				import A = B.C;
+				E;
+			`,
+		});
+
+		t.is(
+			getTSQualifiedBaseFromEntityName(
+				tsQualifiedName.assert(
+					tsImportEqualsDeclaration.assert(js.body[0]).moduleReference,
+				),
+			).name,
+			"B",
+		);
+		t.is(
+			getTSQualifiedBaseFromEntityName(
+				jsReferenceIdentifier.assert(
+					jsExpressionStatement.assert(js.body[1]).expression,
+				),
+			).name,
+			"E",
+		);
+	},
+);


### PR DESCRIPTION
## Summary
Part of #1023 

Adds test for js-ast-utils/getTSQualifiedBaseFromEntityName.ts

## Test Plan

`rome check` is successful.
`rome test` passes all tests.