### PR TITLE
feat: support tslint rule references

### DIFF
--- a/scripts/generated-files/lint-rules-docs.ts
+++ b/scripts/generated-files/lint-rules-docs.ts
@@ -40,15 +40,16 @@ function highlightPre(filename: string, code: string): string {
 }
 
 // Extract the description field from the docs frontmatter
-export function extractESLintRuleInfo(
+export function extractLintRuleInfo(
 	content: string,
+	type: "eslint" | "tslint" = "eslint",
 ):
 	| undefined
 	| {
 			url: string;
 			name: string;
 		} {
-	const match = content.match(/eslint-rule:(.*)(\n|\r\n)/);
+	const match = content.match(new RegExp(`${type}-rule:(.*)(\n|\r\n)`));
 	if (match) {
 		const url = match[1].trim();
 
@@ -130,7 +131,8 @@ export async function main() {
 			},
 			async () => {
 				const content = await readFileText(docs);
-				const eslintInfo = extractESLintRuleInfo(content);
+				const eslintInfo = extractLintRuleInfo(content, "eslint");
+				const tslintInfo = extractLintRuleInfo(content, "tslint");
 
 				const lines = [];
 
@@ -142,6 +144,12 @@ export async function main() {
 				if (eslintInfo !== undefined) {
 					lines.push(
 						`**ESLint Equivalent:** [${eslintInfo.name}](${eslintInfo.url})`,
+					);
+				}
+
+				if (tslintInfo !== undefined) {
+					lines.push(
+						`**TSLint Equivalent:** [${tslintInfo.name}](${tslintInfo.url})`,
 					);
 				}
 

--- a/website/src/docs/lint/rules/ts/useInterfaces.md
+++ b/website/src/docs/lint/rules/ts/useInterfaces.md
@@ -2,7 +2,7 @@
 title: Lint Rule ts/useInterfaces
 layout: layouts/rule.liquid
 description: MISSING DOCUMENTATION
-eslint-rule: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
+tslint-rule: https://palantir.github.io/tslint/rules/interface-over-type-literal/
 eleventyNavigation:
 	key: lint-rules/ts/useInterfaces
 	parent: lint-rules
@@ -11,96 +11,8 @@ eleventyNavigation:
 
 # ts/useInterfaces
 
-<!-- GENERATED:START(hash:d73068d2ce9c2c77289bff157d4d7371ad605383,id:description) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules` to update. -->
+<!-- GENERATED:START(hash:e0e05d932136683720a1ab38dc6632f805ab4bb7,id:description) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules` to update. -->
 MISSING DOCUMENTATION
 
-**ESLint Equivalent:** [jsx-filename-extension](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md)
+**TSLint Equivalent:** [](https://palantir.github.io/tslint/rules/interface-over-type-literal/)
 <!-- GENERATED:END(id:description) -->
-
-<!-- GENERATED:START(hash:5261e89f4402a9ef8bfae90de8acad36b8dc7a72,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
-## Examples
-### Invalid
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">div</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">div</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">test.js:2</span> <strong>lint/jsx/fileExtension</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Files with the </span><span style="color: Tomato;"><strong>.js</strong></span><span style="color: Tomato;"> extension cannot contain JSX elements.</span>
-
-  <strong>  1</strong><strong> │ </strong><span class="token comment">// @jsx</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>&lt;<span class="token attr-name">div</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">div</span>&gt;
-     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
-
-  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Change the </span><span style="color: DodgerBlue;"><strong>test.js</strong></span><span style="color: DodgerBlue;"> file extension to </span><span style="color: DodgerBlue;"><strong>.jsx</strong></span><span style="color: DodgerBlue;"> or </span><span style="color: DodgerBlue;"><strong>.tsx</strong></span><span style="color: DodgerBlue;">.</span>
-
-</code></pre>{% endraw %}
-
----------------
-
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;&gt;&lt;<span class="token operator">/</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">test.js:2</span> <strong>lint/jsx/fileExtension</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Files with the </span><span style="color: Tomato;"><strong>.js</strong></span><span style="color: Tomato;"> extension cannot contain JSX elements.</span>
-
-  <strong>  1</strong><strong> │ </strong><span class="token comment">// @jsx</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>&lt;&gt;&lt;<span class="token operator">/</span>&gt;
-     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
-
-  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Change the </span><span style="color: DodgerBlue;"><strong>test.js</strong></span><span style="color: DodgerBlue;"> file extension to </span><span style="color: DodgerBlue;"><strong>.jsx</strong></span><span style="color: DodgerBlue;"> or </span><span style="color: DodgerBlue;"><strong>.tsx</strong></span><span style="color: DodgerBlue;">.</span>
-
-</code></pre>{% endraw %}
-
----------------
-
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">test.js:2</span> <strong>lint/jsx/fileExtension</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Files with the </span><span style="color: Tomato;"><strong>.js</strong></span><span style="color: Tomato;"> extension cannot contain JSX elements.</span>
-
-  <strong>  1</strong><strong> │ </strong><span class="token comment">// @jsx</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>&lt;<span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">Fragment</span>&gt;
-     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
-
-  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Change the </span><span style="color: DodgerBlue;"><strong>test.js</strong></span><span style="color: DodgerBlue;"> file extension to </span><span style="color: DodgerBlue;"><strong>.jsx</strong></span><span style="color: DodgerBlue;"> or </span><span style="color: DodgerBlue;"><strong>.tsx</strong></span><span style="color: DodgerBlue;">.</span>
-
-</code></pre>{% endraw %}
-
----------------
-
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">test.js:2</span> <strong>lint/jsx/fileExtension</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Files with the </span><span style="color: Tomato;"><strong>.js</strong></span><span style="color: Tomato;"> extension cannot contain JSX elements.</span>
-
-  <strong>  1</strong><strong> │ </strong><span class="token comment">// @jsx</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>&lt;<span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;
-     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
-
-  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Change the </span><span style="color: DodgerBlue;"><strong>test.js</strong></span><span style="color: DodgerBlue;"> file extension to </span><span style="color: DodgerBlue;"><strong>.jsx</strong></span><span style="color: DodgerBlue;"> or </span><span style="color: DodgerBlue;"><strong>.tsx</strong></span><span style="color: DodgerBlue;">.</span>
-
-</code></pre>{% endraw %}
-### Valid
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token string">&apos;&lt;div&gt;&lt;/div&gt;&apos;</span></code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">div</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">div</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;&gt;&lt;<span class="token operator">/</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">div</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">div</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;&gt;&lt;<span class="token operator">/</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-{% raw %}<pre class="language-text"><code class="language-text"><span class="token comment">// @jsx</span>
-&lt;<span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;&lt;<span class="token operator">/</span><span class="token attr-name">React</span><span class="token punctuation">.</span><span class="token attr-name">Fragment</span>&gt;</code></pre>{% endraw %}
-<!-- GENERATED:END(id:examples) -->


### PR DESCRIPTION
## Summary

This pull request updates the `lint-rules-docs` generation script to support TSLint rule references, and updates the documentation and referenced rule for the `ts/useInterfaces` rule to prevent confusion.

Resolves #1130

## Test Plan

```sh
./rome test
```