### PR TITLE
fix(website): update url hash when click TOC links

### DIFF
--- a/website/src/_includes/scripts/index.js
+++ b/website/src/_includes/scripts/index.js
@@ -411,6 +411,7 @@ class Manager {
 
 		if (this.scrollToHeading(href)) {
 			event.preventDefault();
+			location.hash = href;
 		}
 	}
 


### PR DESCRIPTION
close #1170

The event from TOC link click is stoped the default browser behavior of updating URL hash by calling `event.preventDefault()`. Added manually URL hash update after it.
