### PR TITLE
fix: reformated ast-create-node for better readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ The created files will be listed in the console output. See those files for inli
 This is used to generate new ast nodes and boilerplate.
 
 ```bash
-./rome run scripts/ast-create-node [language] [nodeType] [category]
+./rome run scripts/ast-create-node [language]/[category]/[nodeType]
 ```
 
 The `language` is one of the language folders defined in [`https://github.com/romefrontend/rome/tree/main/internal/ast/`]
@@ -142,7 +142,7 @@ The `language` is one of the language folders defined in [`https://github.com/ro
 The `category` is one of the category folders inside the `language` folders.
 
 ```bash
-./rome run scripts/ast-create-node js JSArrayType typescript
+./rome run scripts/ast-create-node js/typescript/JSArrayType
 ```
 
 The created files will be listed in the console output.


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1161 

You can now create new `AST` nodes by following how the folders and files are currently structured in the `ast/` folder.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

To create a new AST node by the name of `TSSomeNode.ts`, now you can run
`scripts/ast-create-node js/typescript/TSSomeNode`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
