### PR TITLE
fix(website): Sidebar list items width (#1162)

### DIFF
--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -66,6 +66,7 @@
 	}
 
 	a {
+		max-width: calc(100% - 16px);
 		text-decoration: none;
 		text-overflow: ellipsis;
 		overflow: hidden;


### PR DESCRIPTION
Hello,

## Summary

This correction aims to correct an existing problem (#1162), the sidebar overflow.

### Preview
> Look at the item `dependencies.exceptions.invalidLicenses`
<img width="1249" alt="hover-effect" src="https://user-images.githubusercontent.com/5417662/92336757-f1781f80-f09b-11ea-846a-f50e850482b4.png">
