### PR TITLE
fix: create-lint-rule script

### DIFF
--- a/scripts/lint-create-rule.ts
+++ b/scripts/lint-create-rule.ts
@@ -66,7 +66,7 @@ export async function main([ruleName]: Array<string>): Promise<number> {
 	// Write docs
 	await writeFile(
 		ROOT.append("website", "src", "docs", "lint", "rules", `${ruleName}.md`),
-		`
+		dedent`
 			---
 			title: Lint Rule ${ruleName}
 			layout: layouts/rule.liquid
@@ -91,11 +91,12 @@ export async function main([ruleName]: Array<string>): Promise<number> {
 		"lint.ts",
 	);
 	let descriptions = await readFileText(diagDescriptionsPath);
+	let message = "markup`INSERT MESSAGE HERE`";
 	descriptions = descriptions.replace(
 		"createDiagnosticsCategory({",
 		`createDiagnosticsCategory({\n	${descriptionKey}: {
 			category: "${categoryName}",
-			message: "INSERT MESSAGE HERE",
+			message: ${message},
 		},`,
 	);
 	await writeFile(diagDescriptionsPath, descriptions);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary
current `create-lint-rule` script breaks the documentation of that rule in the website by default because of indentation and it doesn't export lint message correctly. this PR fixes those.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
`./rome test`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
