### PR TITLE
fix(website): Janky scrolling

### DIFF
--- a/website/src/_includes/scripts/index.js
+++ b/website/src/_includes/scripts/index.js
@@ -219,7 +219,7 @@ class Manager {
 
 		if (activating) {
 			document.title = `${titles.join(": ")} — ${originalTitle}`;
-			history.replaceState({}, '', link.getAttribute("href"));
+			history.replaceState({}, "", link.getAttribute("href"));
 		} else {
 			document.title = originalTitle;
 		}

--- a/website/src/_includes/scripts/index.js
+++ b/website/src/_includes/scripts/index.js
@@ -219,7 +219,7 @@ class Manager {
 
 		if (activating) {
 			document.title = `${titles.join(": ")} — ${originalTitle}`;
-			window.location.hash = link.getAttribute("href");
+			history.replaceState({}, '', link.getAttribute("href"));
 		} else {
 			document.title = originalTitle;
 		}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/romefrontend/rome/blob/main/CONTRIBUTING.md
-->

## Summary
Scrolling over the headings on the website feels very choppy and the browser history gets filled with entries for each and every heading element. [History.replaceState()](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) fixes both issues.

If populating the browser history for each scrolled over heading is the intended behavior, this can be changed to use [History.pushState()](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) instead.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
