### PR TITLE
test: js-ast-utils/isEmptyTemplateLiteral

### DIFF
--- a/internal/js-ast-utils/isEmptyTemplateLiteral.test.ts
+++ b/internal/js-ast-utils/isEmptyTemplateLiteral.test.ts
@@ -1,0 +1,54 @@
+import {test} from "rome";
+import {jsTemplateElement, jsTemplateLiteral} from "@internal/ast";
+import {isEmptyTemplateLiteral} from "@internal/js-ast-utils/isEmptyTemplateLiteral";
+
+test(
+	"returns whether the template literal is empty",
+	async (t) => {
+		t.false(
+			isEmptyTemplateLiteral(
+				jsTemplateLiteral.create({
+					expressions: [],
+					quasis: [
+						jsTemplateElement.create({
+							cooked: "foo",
+							raw: "bar",
+						}),
+					],
+				}),
+			),
+		);
+
+		t.false(
+			isEmptyTemplateLiteral(
+				jsTemplateLiteral.create({
+					expressions: [],
+					quasis: [
+						jsTemplateElement.create({
+							cooked: "",
+							raw: "",
+						}),
+						jsTemplateElement.create({
+							cooked: "",
+							raw: "",
+						}),
+					],
+				}),
+			),
+		);
+
+		t.true(
+			isEmptyTemplateLiteral(
+				jsTemplateLiteral.create({
+					expressions: [],
+					quasis: [
+						jsTemplateElement.create({
+							cooked: "",
+							raw: "test",
+						}),
+					],
+				}),
+			),
+		);
+	},
+);


### PR DESCRIPTION
## Summary
Part of #1023 

Adds test for js-ast-utils/isEmptyTemplateLiteral.ts

## Test Plan

`rome check` is successful.
`rome test` passes all tests.