### PR TITLE
Simplify code contributions + reviews by fully automating the dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+  - before: cd website
+    init: npm install
+    command: npm start
+ports:
+  - port: 8080
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,16 @@ cd rome
 ./rome --help
 ```
 
+### Online one-click setup for contributing
+
+You can use Gitpod(an Online Open Source VS Code like IDE which is free for Open Source) for working on issues and making PRs to this repo. With a single click it will start a workspace and automatically:
+
+- clone the `rome` repo.
+- install the dependencies in `/website`.
+- run `npm start` in `/website`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Developing on Windows
 
 You need to use the backslash (`\`) to run any `rome` command on Windows instead of the slash (`/`); Windows uses backslashes for file paths.


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `rome` repo.
- install the dependencies in `/website`.
- run `npm start` in `/website`.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/rome

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95645311-2b8f7380-0ad7-11eb-9afc-576b98b78e89.png)

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

 